### PR TITLE
Feat: Native Histogram 저장용 OpenMxHistogram 타입/Pack 추가 (KAZAA-592)

### DIFF
--- a/pkg/model/open_mx_histogram.go
+++ b/pkg/model/open_mx_histogram.go
@@ -1,0 +1,161 @@
+package model
+
+import (
+	"github.com/whatap/golib/io"
+)
+
+// BucketSpan describes a contiguous run of populated buckets in a Prometheus
+// Native (sparse) Histogram. It mirrors io.prometheus.client.BucketSpan:
+//   - Offset is the gap (in bucket indexes) from the end of the previous span,
+//     or from the implicit zero index for the first span. It may be negative.
+//   - Length is the number of consecutive buckets covered by this span.
+type BucketSpan struct {
+	Offset int32
+	Length uint32
+}
+
+// NativeHistogramData holds the sparse, exponential-bucket payload of a
+// Prometheus Native Histogram. Bucket counts are delta-encoded int64s, carried
+// verbatim from the protobuf exposition format (io.prometheus.client.Histogram):
+// the first entry of each *Buckets slice is an absolute count and every later
+// entry is the delta from its predecessor.
+//
+// A nil/zero-valued NativeHistogramData is meaningless on its own; it is always
+// the payload of an OpenMxHistogram.
+type NativeHistogramData struct {
+	// Schema selects the bucket resolution. The bucket boundaries are
+	// 2^(2^-Schema). Valid Prometheus values are currently -4..8.
+	Schema int32
+	// ZeroThreshold is the width of the zero bucket (observations whose
+	// absolute value is <= ZeroThreshold fall into the zero bucket).
+	ZeroThreshold float64
+	// ZeroCount is the number of observations in the zero bucket.
+	ZeroCount uint64
+	// Count is the total number of observations across all buckets.
+	Count uint64
+	// Sum is the sum of all observed values.
+	Sum float64
+
+	// PositiveSpans / PositiveBuckets describe buckets for positive values.
+	PositiveSpans   []BucketSpan
+	PositiveBuckets []int64
+	// NegativeSpans / NegativeBuckets describe buckets for negative values.
+	NegativeSpans   []BucketSpan
+	NegativeBuckets []int64
+}
+
+// OpenMxHistogram represents a single Native Histogram sample. It is a sibling
+// of OpenMx (which stays scalar-only) so that the existing OpenMx wire format
+// and the server's scalar decode path are left completely untouched. Native
+// Histograms travel in their own OpenMxHistogramPack (see open_mx_histogram_pack.go).
+//
+// Classic histograms are NOT represented here: in Prometheus text/OpenMetrics
+// exposition a classic histogram is already a set of plain scalar series
+// (_bucket, _sum, _count) and continues to flow through OpenMx unchanged.
+type OpenMxHistogram struct {
+	Metric    string
+	Timestamp int64
+	Labels    []Label
+	Data      NativeHistogramData
+}
+
+// NewOpenMxHistogram creates a new OpenMxHistogram with the given identity.
+func NewOpenMxHistogram(metric string, timestamp int64) *OpenMxHistogram {
+	return &OpenMxHistogram{
+		Metric:    metric,
+		Timestamp: timestamp,
+		Labels:    make([]Label, 0),
+	}
+}
+
+// AddLabel appends a label to the histogram sample.
+func (h *OpenMxHistogram) AddLabel(key, value string) {
+	h.Labels = append(h.Labels, Label{Key: key, Value: value})
+}
+
+// Write serializes an OpenMxHistogram to a DataOutputX. The leading version
+// byte mirrors OpenMx/OpenMxHelp and allows forward-compatible field additions.
+func (h *OpenMxHistogram) Write(o *io.DataOutputX) {
+	o.WriteByte(0) // version
+	o.WriteText(h.Metric)
+
+	labelSize := len(h.Labels)
+	o.WriteByte(byte(labelSize))
+	for i := 0; i < labelSize; i++ {
+		h.Labels[i].Write(o)
+	}
+
+	o.WriteLong(h.Timestamp)
+	h.Data.write(o)
+}
+
+// Read deserializes an OpenMxHistogram from a DataInputX.
+func (h *OpenMxHistogram) Read(in *io.DataInputX) *OpenMxHistogram {
+	_ = in.ReadByte() // version
+	h.Metric = in.ReadText()
+
+	cnt := int(in.ReadByte())
+	if cnt > 0 {
+		h.Labels = make([]Label, cnt)
+		for i := 0; i < cnt; i++ {
+			h.Labels[i] = *new(Label).Read(in)
+		}
+	}
+
+	h.Timestamp = in.ReadLong()
+	h.Data.read(in)
+
+	return h
+}
+
+// write serializes the native histogram payload.
+func (d *NativeHistogramData) write(o *io.DataOutputX) {
+	o.WriteInt(d.Schema)
+	o.WriteDouble(d.ZeroThreshold)
+	o.WriteLong(int64(d.ZeroCount))
+	o.WriteLong(int64(d.Count))
+	o.WriteDouble(d.Sum)
+
+	writeBucketSpans(o, d.PositiveSpans)
+	o.WriteLongArray(d.PositiveBuckets)
+	writeBucketSpans(o, d.NegativeSpans)
+	o.WriteLongArray(d.NegativeBuckets)
+}
+
+// read deserializes the native histogram payload.
+func (d *NativeHistogramData) read(in *io.DataInputX) {
+	d.Schema = in.ReadInt()
+	d.ZeroThreshold = in.ReadDouble()
+	d.ZeroCount = uint64(in.ReadLong())
+	d.Count = uint64(in.ReadLong())
+	d.Sum = in.ReadDouble()
+
+	d.PositiveSpans = readBucketSpans(in)
+	d.PositiveBuckets = in.ReadLongArray()
+	d.NegativeSpans = readBucketSpans(in)
+	d.NegativeBuckets = in.ReadLongArray()
+}
+
+// writeBucketSpans serializes a slice of BucketSpan. A short length prefix keeps
+// it compact while allowing far more spans than a histogram realistically has.
+func writeBucketSpans(o *io.DataOutputX, spans []BucketSpan) {
+	o.WriteShort(int16(len(spans)))
+	for i := range spans {
+		o.WriteInt(spans[i].Offset)
+		o.WriteInt(int32(spans[i].Length))
+	}
+}
+
+// readBucketSpans deserializes a slice of BucketSpan.
+func readBucketSpans(in *io.DataInputX) []BucketSpan {
+	n := int(in.ReadShort())
+	if n <= 0 {
+		return nil
+	}
+	spans := make([]BucketSpan, n)
+	for i := 0; i < n; i++ {
+		spans[i].Offset = in.ReadInt()
+		spans[i].Length = uint32(in.ReadInt())
+	}
+	return spans
+}

--- a/pkg/model/open_mx_histogram_pack.go
+++ b/pkg/model/open_mx_histogram_pack.go
@@ -8,12 +8,11 @@ import (
 
 // Pack type constant for OpenMxHistogramPack.
 //
-// NOTE: 0x1605 is the next free value after OPEN_MX_PACK (0x1603) and
-// OPEN_MX_HELP_PACK (0x1604). The final number MUST be confirmed with the
-// WhaTap collection-server team so it does not collide with any pack type
-// already registered server-side (see KAZAA-592 design doc, server coordination).
+// 0x1607 is the value agreed with the WhaTap collection-server team (KAZAA-593):
+// the original 0x1605 proposal collides with TAG_META in the server-side
+// PackEnum, so 0x1607 was confirmed against apm-server PackEnum.java.
 const (
-	OPEN_MX_HISTOGRAM_PACK = 0x1605
+	OPEN_MX_HISTOGRAM_PACK = 0x1607
 )
 
 // OpenMxHistogramPack represents a pack of OpenMxHistogram records for sending

--- a/pkg/model/open_mx_histogram_pack.go
+++ b/pkg/model/open_mx_histogram_pack.go
@@ -1,0 +1,115 @@
+package model
+
+import (
+	"github.com/whatap/golib/io"
+	"github.com/whatap/golib/lang/pack"
+	"github.com/whatap/golib/util/compressutil"
+)
+
+// Pack type constant for OpenMxHistogramPack.
+//
+// NOTE: 0x1605 is the next free value after OPEN_MX_PACK (0x1603) and
+// OPEN_MX_HELP_PACK (0x1604). The final number MUST be confirmed with the
+// WhaTap collection-server team so it does not collide with any pack type
+// already registered server-side (see KAZAA-592 design doc, server coordination).
+const (
+	OPEN_MX_HISTOGRAM_PACK = 0x1605
+)
+
+// OpenMxHistogramPack represents a pack of OpenMxHistogram records for sending
+// to the server. It mirrors OpenMxPack so the existing send/compress plumbing
+// applies unchanged, but uses a distinct pack type so the server can route
+// native histograms to a dedicated handler without touching the scalar path.
+type OpenMxHistogramPack struct {
+	pack.AbstractPack
+	zip     byte
+	bytes   []byte
+	records []*OpenMxHistogram
+}
+
+// GetPackType returns the pack type.
+func (p *OpenMxHistogramPack) GetPackType() int16 {
+	return OPEN_MX_HISTOGRAM_PACK
+}
+
+// Write serializes the pack to a DataOutputX.
+func (p *OpenMxHistogramPack) Write(dout *io.DataOutputX) {
+	p.AbstractPack.Write(dout)
+	if p.bytes == nil {
+		p.reset(p.records)
+	}
+	dout.WriteByte(p.zip)
+	dout.WriteBlob(p.bytes)
+}
+
+// Read deserializes the pack from a DataInputX.
+func (p *OpenMxHistogramPack) Read(din *io.DataInputX) {
+	p.AbstractPack.Read(din)
+	p.zip = din.ReadByte()
+	p.bytes = din.ReadBlob()
+}
+
+// SetRecords sets the records for the pack.
+func (p *OpenMxHistogramPack) SetRecords(items []*OpenMxHistogram) *OpenMxHistogramPack {
+	p.records = items
+	return p.reset(items)
+}
+
+// reset resets the pack with the given records.
+func (p *OpenMxHistogramPack) reset(items []*OpenMxHistogram) *OpenMxHistogramPack {
+	o := io.NewDataOutputX()
+	o.WriteByte(0) // version
+
+	if items == nil {
+		o.WriteShort(0)
+	} else {
+		o.WriteShort(int16(len(items)))
+		for i := 0; i < len(items); i++ {
+			items[i].Write(o)
+		}
+	}
+
+	p.bytes = o.ToByteArray()
+	if len(p.bytes) > 100 {
+		p.zip = 1
+		compressed, err := compressutil.DoZip(p.bytes)
+		if err == nil {
+			p.bytes = compressed
+		}
+	}
+
+	return p
+}
+
+// GetRecords returns the records from the pack.
+func (p *OpenMxHistogramPack) GetRecords() []*OpenMxHistogram {
+	if p.bytes == nil {
+		return nil
+	}
+
+	var in *io.DataInputX
+	if p.zip == 1 {
+		unzipped, err := compressutil.UnZip(p.bytes)
+		if err != nil {
+			return nil
+		}
+		in = io.NewDataInputX(unzipped)
+	} else {
+		in = io.NewDataInputX(p.bytes)
+	}
+
+	p.records = make([]*OpenMxHistogram, 0)
+	_ = in.ReadByte() // version
+	size := int(in.ReadShort())
+
+	for i := 0; i < size; i++ {
+		p.records = append(p.records, new(OpenMxHistogram).Read(in))
+	}
+
+	return p.records
+}
+
+// NewOpenMxHistogramPack creates a new OpenMxHistogramPack.
+func NewOpenMxHistogramPack() *OpenMxHistogramPack {
+	return &OpenMxHistogramPack{}
+}

--- a/pkg/model/open_mx_histogram_test.go
+++ b/pkg/model/open_mx_histogram_test.go
@@ -1,0 +1,112 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/whatap/golib/io"
+)
+
+// sampleHistogram returns a fully-populated OpenMxHistogram for round-trip tests.
+func sampleHistogram() *OpenMxHistogram {
+	h := NewOpenMxHistogram("http_request_duration_seconds", 1718668800000)
+	h.AddLabel("service", "checkout")
+	h.AddLabel("method", "POST")
+	h.Data = NativeHistogramData{
+		Schema:        3,
+		ZeroThreshold: 1e-9,
+		ZeroCount:     2,
+		Count:         42,
+		Sum:           123.456,
+		PositiveSpans: []BucketSpan{
+			{Offset: 0, Length: 3},
+			{Offset: 2, Length: 1},
+		},
+		PositiveBuckets: []int64{5, -2, 1, 3}, // delta-encoded
+		NegativeSpans: []BucketSpan{
+			{Offset: -1, Length: 2},
+		},
+		NegativeBuckets: []int64{1, 4},
+	}
+	return h
+}
+
+func TestOpenMxHistogram_WriteRead(t *testing.T) {
+	orig := sampleHistogram()
+
+	o := io.NewDataOutputX()
+	orig.Write(o)
+
+	in := io.NewDataInputX(o.ToByteArray())
+	got := new(OpenMxHistogram).Read(in)
+
+	if !reflect.DeepEqual(orig, got) {
+		t.Fatalf("round-trip mismatch:\n orig=%+v\n  got=%+v", orig, got)
+	}
+}
+
+func TestOpenMxHistogram_EmptyBuckets(t *testing.T) {
+	// A native histogram with no populated buckets must still round-trip its
+	// scalar fields. Empty bucket arrays come back as empty (non-nil) slices.
+	orig := NewOpenMxHistogram("empty_histo", 1718668800000)
+	orig.Data = NativeHistogramData{
+		Schema:        0,
+		ZeroThreshold: 0,
+		ZeroCount:     0,
+		Count:         0,
+		Sum:           0,
+	}
+
+	o := io.NewDataOutputX()
+	orig.Write(o)
+	got := new(OpenMxHistogram).Read(io.NewDataInputX(o.ToByteArray()))
+
+	if got.Metric != orig.Metric || got.Timestamp != orig.Timestamp {
+		t.Fatalf("identity mismatch: got metric=%q ts=%d", got.Metric, got.Timestamp)
+	}
+	if got.Data.Schema != 0 || got.Data.Count != 0 {
+		t.Fatalf("scalar fields mismatch: %+v", got.Data)
+	}
+	if len(got.Data.PositiveBuckets) != 0 || len(got.Data.NegativeBuckets) != 0 {
+		t.Fatalf("expected no buckets, got pos=%v neg=%v", got.Data.PositiveBuckets, got.Data.NegativeBuckets)
+	}
+	if len(got.Data.PositiveSpans) != 0 || len(got.Data.NegativeSpans) != 0 {
+		t.Fatalf("expected no spans, got pos=%v neg=%v", got.Data.PositiveSpans, got.Data.NegativeSpans)
+	}
+}
+
+func TestOpenMxHistogramPack_RoundTrip(t *testing.T) {
+	records := []*OpenMxHistogram{sampleHistogram(), sampleHistogram(), sampleHistogram()}
+
+	pk := NewOpenMxHistogramPack()
+	pk.SetRecords(records)
+
+	// Serialize the whole pack (exercises the compress path for >100 bytes)...
+	o := io.NewDataOutputX()
+	pk.Write(o)
+
+	// ...and read it back through a fresh pack instance.
+	decoded := NewOpenMxHistogramPack()
+	decoded.Read(io.NewDataInputX(o.ToByteArray()))
+
+	got := decoded.GetRecords()
+	if len(got) != len(records) {
+		t.Fatalf("record count mismatch: want %d, got %d", len(records), len(got))
+	}
+	for i := range records {
+		if !reflect.DeepEqual(records[i], got[i]) {
+			t.Fatalf("record %d mismatch:\n want=%+v\n  got=%+v", i, records[i], got[i])
+		}
+	}
+}
+
+func TestOpenMxHistogramPack_PackType(t *testing.T) {
+	if got := NewOpenMxHistogramPack().GetPackType(); got != OPEN_MX_HISTOGRAM_PACK {
+		t.Fatalf("pack type = 0x%x, want 0x%x", got, OPEN_MX_HISTOGRAM_PACK)
+	}
+	// Must not collide with the existing scalar / help pack types.
+	if OPEN_MX_HISTOGRAM_PACK == OPEN_MX_PACK || OPEN_MX_HISTOGRAM_PACK == OPEN_MX_HELP_PACK {
+		t.Fatalf("pack type collision: histo=0x%x mx=0x%x help=0x%x",
+			OPEN_MX_HISTOGRAM_PACK, OPEN_MX_PACK, OPEN_MX_HELP_PACK)
+	}
+}


### PR DESCRIPTION
## 개요 (KAZAA-592)

Native Histogram 지원을 위한 OpenMx 저장 스키마 확장. **Option B(별도 타입 + 신규 Pack)** 채택.

기존 `OpenMx` 스칼라 와이어 포맷을 **전혀 건드리지 않도록** native histogram을 별도 타입/Pack으로 분리한다.

## 변경 사항

| 파일 | 내용 |
|---|---|
| `pkg/model/open_mx_histogram.go` | `BucketSpan`, `NativeHistogramData`, `OpenMxHistogram` + `Write`/`Read` 직렬화 (레코드 버전 바이트 포함) |
| `pkg/model/open_mx_histogram_pack.go` | `OpenMxHistogramPack` (pack type `0x1605`), 기존 `OpenMxPack`과 동일 골격 + zip 압축 |
| `pkg/model/open_mx_histogram_test.go` | 레코드/Pack/빈 버킷/Pack타입 충돌 라운드트립 테스트 |

기존 `OpenMx`/`OpenMxPack`/converter **무수정**.

## Option B 선택 근거 (요약)

- **하위 호환성**: 기존 OpenMx 와이어 포맷 무변경 → 스칼라 + classic-histogram(이미 스칼라 시계열로 처리됨) 경로 100% 보존
- **서버 롤아웃**: 서버는 기존 핫패스 디코더 수정 없이 `0x1605` 핸들러만 추가 → lockstep 배포 불필요, 단계적 롤아웃 가능
- **저장/Dual format**: native는 전용 타입으로, classic은 기존 스칼라로 분리 → 저장 비용·중복 판정이 타입 경계에서 자연스럽게 분리
- 아키텍처 정합: `OpenMxHelpPack(0x1604)` 등 병렬 타입 Pack은 이미 확립된 패턴

전체 설계 문서(Option A/B 상세 비교, 와이어 포맷 명세)는 KAZAA-592 이슈 document 참조. (`docs/`는 repo .gitignore 대상이라 PR에 미포함)

## 검증

- `go build ./pkg/...` ✅
- `go test ./pkg/model/...` ✅ (라운드트립 4종 통과)
- `go vet ./pkg/model/...` ✅

## 스코프 / 후속 (의도적 제외)

- sender/processor 전송 연결 — **서버팀 수신 포맷(와이어 필드, Pack 번호 `0x1605`) 확정 후** 별도 PR
- protobuf → `OpenMxHistogram` 변환 — KAZAA-589(Protobuf 스크랩) 본체

> ⚠️ Pack 타입 `0x1605`는 제안값. 서버 Pack 레지스트리 충돌 방지를 위해 서버팀 최종 확정 필요.

## 관련 이슈

- KAZAA-592 (본 이슈), unblock 대상: KAZAA-589
- 선행: KAZAA-585, KAZAA-587

🤖 Generated with [Claude Code](https://claude.com/claude-code)