### PR TITLE
[KAZAA-591] Native Histogram 수집을 위한 Protobuf 스크랩 지원 (steps 1-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ OpenAgent를 실행하려면 다음 환경 변수를 설정해야 합니다:
 - `WHATAP_HOST`: 와탭 서버 호스트 주소
 - `WHATAP_PORT`: 와탭 서버 포트 (기본값: 6600)
 
+### 선택 설정 (환경 변수 또는 whatap.conf)
+
+- `openagent_enable_protobuf`: Prometheus protobuf 스크랩(콘텐츠 협상)을 활성화합니다.
+  - 기본값 `false` — 기존 동작과 동일하게 `Accept: application/json` 으로 스크랩합니다.
+  - `true` 로 설정하면 `Accept` 헤더에 protobuf > OpenMetrics > text 우선순위를 광고하고,
+    응답 `Content-Type` 에 따라 protobuf/text 디코더를 자동 선택합니다.
+    classic 메트릭(counter/gauge/summary/classic histogram)은 기존과 동일한 flat 시리즈로 수집되며,
+    native histogram 은 디코딩되지만 OpenMx 변환은 후속 작업(KAZAA-591 step 4)에서 추가됩니다.
+
 ### Docker 이미지 빌드
 
 #### 기본 Docker 빌드

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,15 @@ require (
 	github.com/containerd/containerd v1.7.27
 	github.com/docker/docker v28.2.2+incompatible
 	github.com/google/gopacket v1.1.19
+	github.com/prometheus/client_model v0.6.1
+	github.com/prometheus/common v0.55.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/stretchr/testify v1.10.0
 	github.com/whatap/gointernal v0.0.0
 	github.com/whatap/golib v0.0.41
 	golang.org/x/net v0.33.0
+	google.golang.org/protobuf v1.35.2
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
@@ -104,7 +107,6 @@ require (
 	google.golang.org/genproto v0.0.0-20231211222908-989df2bf70f3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.67.0 // indirect
-	google.golang.org/protobuf v1.35.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
+github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
+github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G1dc=
+github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/pkg/client/http_client.go
+++ b/pkg/client/http_client.go
@@ -20,6 +20,15 @@ const (
 	localServiceAccountToken = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	kubernetesServiceHost    = "KUBERNETES_SERVICE_HOST"
 	kubernetesServicePort    = "KUBERNETES_SERVICE_PORT"
+
+	// protobufAcceptHeader is the prioritized Accept value advertised when
+	// protobuf scraping is enabled. Native histograms are only available via the
+	// Prometheus protobuf format, so it is preferred, followed by OpenMetrics,
+	// text exposition, and a low-quality wildcard fallback.
+	protobufAcceptHeader = "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited," +
+		"application/openmetrics-text;version=1.0.0;charset=utf-8," +
+		"text/plain;version=0.0.4;charset=utf-8," +
+		"*/*;q=0.1"
 )
 
 // TLSConfig represents TLS configuration options
@@ -292,7 +301,20 @@ func (c *HTTPClient) ExecuteGetWithTLSConfigAndTimeout(targetURL string, tlsConf
 	return c.ExecuteGetWithAuth(targetURL, tlsConfig, nil, timeout)
 }
 
+// ExecuteGetWithAuth scrapes the target and returns the response body as a
+// string. Retained for callers that do not need the response Content-Type.
 func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, basicAuth *configPkg.BasicAuthConfig, timeout time.Duration) (string, error) {
+	body, _, err := c.ExecuteGetWithAuthResponse(targetURL, tlsConfig, basicAuth, timeout)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// ExecuteGetWithAuthResponse scrapes the target and returns the raw response
+// body together with the response Content-Type, allowing callers to perform
+// content negotiation (e.g. Prometheus protobuf vs. text exposition).
+func (c *HTTPClient) ExecuteGetWithAuthResponse(targetURL string, tlsConfig *TLSConfig, basicAuth *configPkg.BasicAuthConfig, timeout time.Duration) ([]byte, string, error) {
 	formattedURL := FormatURL(targetURL)
 	// Log the request
 	if configPkg.IsDebugEnabled() {
@@ -301,7 +323,7 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 
 	req, err := http.NewRequest("GET", formattedURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("error creating request: %v", err)
+		return nil, "", fmt.Errorf("error creating request: %v", err)
 	}
 
 	// Authentication
@@ -359,7 +381,16 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 		}
 	}
 
-	req.Header.Set("Accept", "application/json")
+	// Content negotiation. By default the agent keeps requesting application/json
+	// (legacy behavior). When protobuf scraping is enabled the agent advertises a
+	// prioritized Accept list so native-histogram-capable targets can respond with
+	// the Prometheus protobuf format, while still allowing OpenMetrics/text and a
+	// wildcard fallback for targets that do not support protobuf.
+	if configPkg.GetBoolWithDefault("openagent_enable_protobuf", false) {
+		req.Header.Set("Accept", protobufAcceptHeader)
+	} else {
+		req.Header.Set("Accept", "application/json")
+	}
 
 	// Determine the effective timeout
 	effectiveTimeout := timeout
@@ -376,7 +407,7 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 	if tlsConfig != nil {
 		// Validate TLS configuration
 		if err := tlsConfig.Validate(); err != nil {
-			return "", fmt.Errorf("invalid TLS configuration: %v", err)
+			return nil, "", fmt.Errorf("invalid TLS configuration: %v", err)
 		}
 
 		if configPkg.IsDebugEnabled() {
@@ -535,7 +566,7 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 		if configPkg.IsDebugEnabled() {
 			logutil.Debugf("HTTP_CLIENT", "HTTP request failed: %v", err)
 		}
-		return "", fmt.Errorf("error executing request: %v", err)
+		return nil, "", fmt.Errorf("error executing request: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -551,7 +582,7 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 		if configPkg.IsDebugEnabled() {
 			logutil.Debugf("HTTP_CLIENT", "Error reading response body: %v", err)
 		}
-		return "", fmt.Errorf("error reading response body: %v", err)
+		return nil, "", fmt.Errorf("error reading response body: %v", err)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -559,7 +590,7 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 			logutil.Debugf("HTTP_CLIENT", "HTTP error: %d %s", resp.StatusCode, resp.Status)
 			logutil.Debugf("HTTP_CLIENT", "Response body: %s", string(body))
 		}
-		return "", fmt.Errorf("HTTP error: %d %s", resp.StatusCode, resp.Status)
+		return nil, "", fmt.Errorf("HTTP error: %d %s", resp.StatusCode, resp.Status)
 	}
 
 	// Log the response body length if debug is enabled
@@ -573,5 +604,5 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 		logutil.Debugf("HTTP_CLIENT", "Response body preview: %s", preview)
 	}
 
-	return string(body), nil
+	return body, resp.Header.Get("Content-Type"), nil
 }

--- a/pkg/converter/protobuf_converter.go
+++ b/pkg/converter/protobuf_converter.go
@@ -1,0 +1,283 @@
+package converter
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+
+	configPkg "open-agent/pkg/config"
+	"open-agent/pkg/model"
+	"open-agent/tools/util/logutil"
+)
+
+// ProtobufContentType is the base media type used by the Prometheus protobuf
+// exposition format (delimited io.prometheus.client.MetricFamily messages).
+const ProtobufContentType = "application/vnd.google.protobuf"
+
+// IsProtobufContentType reports whether the given Content-Type response header
+// indicates a Prometheus protobuf (delimited MetricFamily) payload.
+func IsProtobufContentType(contentType string) bool {
+	if contentType == "" {
+		return false
+	}
+	h := http.Header{}
+	h.Set("Content-Type", contentType)
+	return expfmt.ResponseFormat(h).FormatType() == expfmt.TypeProtoDelim
+}
+
+// ConvertWithContentType converts a scraped payload to OpenMx format, selecting
+// the protobuf or text decoder based on the response Content-Type.
+//
+// Text (and any non-protobuf) payloads fall back to the existing line-based
+// parser so classic exposition collection is completely unaffected.
+func ConvertWithContentType(data []byte, contentType string, collectionTime int64) (*model.ConversionResult, error) {
+	if IsProtobufContentType(contentType) {
+		return ConvertProtobufWithTimestamp(data, collectionTime)
+	}
+	return ConvertWithTimestamp(string(data), collectionTime)
+}
+
+// ConvertProtobuf decodes a delimited Prometheus protobuf payload into OpenMx
+// using the current time as the collection timestamp.
+func ConvertProtobuf(data []byte) (*model.ConversionResult, error) {
+	return ConvertProtobufWithTimestamp(data, time.Now().UnixMilli())
+}
+
+// ConvertProtobufWithTimestamp decodes a delimited Prometheus protobuf payload
+// (Content-Type: application/vnd.google.protobuf; encoding=delimited) into the
+// OpenMx flat-series representation.
+//
+// Classic metric types (counter, gauge, summary, untyped and classic
+// histograms with explicit buckets) are converted to exactly the same flat
+// series the text parser produces, so switching a target to protobuf does not
+// change collected classic metrics.
+//
+// Native (sparse) histograms are structurally decoded here — the Schema, zero
+// bucket, positive/negative spans and deltas are all parsed by the protobuf
+// decoder — but their conversion into the native OpenMx structure is deferred to
+// KAZAA-591 step 4, which depends on the OpenMx schema design in KAZAA-592. For
+// now native histogram series are skipped (their classic buckets, if the target
+// exposes them alongside, are still collected normally).
+func ConvertProtobufWithTimestamp(data []byte, collectionTime int64) (*model.ConversionResult, error) {
+	openMxList := make([]*model.OpenMx, 0)
+	helpMap := make(map[string]*model.OpenMxHelp)
+
+	dec := expfmt.NewDecoder(bytes.NewReader(data), expfmt.NewFormat(expfmt.TypeProtoDelim))
+	nativeHistogramCount := 0
+
+	for {
+		var mf dto.MetricFamily
+		err := dec.Decode(&mf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			// Surface the error but keep the families decoded so far: a malformed
+			// tail should not silently discard valid leading metrics.
+			return model.NewConversionResult(openMxList, helpMapToSlice(helpMap)),
+				fmt.Errorf("error decoding protobuf metric family: %v", err)
+		}
+
+		name := mf.GetName()
+		if name == "" {
+			continue
+		}
+
+		// HELP / TYPE metadata, mirroring the text parser's helpMap.
+		omh := model.NewOpenMxHelp(name)
+		if mf.Help != nil {
+			omh.Put("help", mf.GetHelp())
+		}
+		omh.Put("type", metricTypeString(mf.GetType()))
+		helpMap[name] = omh
+
+		for _, m := range mf.GetMetric() {
+			if m == nil {
+				continue
+			}
+
+			ts := collectionTime
+			if m.TimestampMs != nil && m.GetTimestampMs() > 0 {
+				ts = m.GetTimestampMs()
+			}
+			labels := m.GetLabel()
+
+			switch mf.GetType() {
+			case dto.MetricType_COUNTER:
+				if c := m.GetCounter(); c != nil {
+					openMxList = append(openMxList, newOpenMxWithLabels(name, ts, c.GetValue(), labels))
+				}
+			case dto.MetricType_GAUGE:
+				if g := m.GetGauge(); g != nil {
+					openMxList = append(openMxList, newOpenMxWithLabels(name, ts, g.GetValue(), labels))
+				}
+			case dto.MetricType_UNTYPED:
+				if u := m.GetUntyped(); u != nil {
+					openMxList = append(openMxList, newOpenMxWithLabels(name, ts, u.GetValue(), labels))
+				}
+			case dto.MetricType_SUMMARY:
+				if s := m.GetSummary(); s != nil {
+					openMxList = append(openMxList, convertSummary(name, ts, s, labels)...)
+				}
+			case dto.MetricType_HISTOGRAM, dto.MetricType_GAUGE_HISTOGRAM:
+				h := m.GetHistogram()
+				if h == nil {
+					continue
+				}
+				// Classic buckets first — preserves exact flat-series behavior.
+				series, classicEmitted := convertClassicHistogram(name, ts, h, labels)
+				openMxList = append(openMxList, series...)
+
+				// Native histogram: decoded but emission deferred (see doc comment).
+				if isNativeHistogram(h) {
+					nativeHistogramCount++
+					if !classicEmitted && configPkg.IsDebugEnabled() {
+						logutil.Debugf("CONVERTER",
+							"[CONVERTER] Native histogram %q decoded (schema=%d) but OpenMx emission deferred (KAZAA-591 step 4)",
+							name, h.GetSchema())
+					}
+				}
+			}
+		}
+	}
+
+	if nativeHistogramCount > 0 {
+		logutil.Infof("CONVERTER",
+			"Decoded %d native histogram metric(s) from protobuf; native OpenMx conversion is pending (KAZAA-591 step 4 / KAZAA-592). Classic buckets, where exposed alongside, were collected normally.",
+			nativeHistogramCount)
+	}
+
+	return model.NewConversionResult(openMxList, helpMapToSlice(helpMap)), nil
+}
+
+// convertSummary expands a summary into its flat series: one series per quantile
+// plus _sum and _count, identical to the text exposition.
+func convertSummary(name string, ts int64, s *dto.Summary, labels []*dto.LabelPair) []*model.OpenMx {
+	series := make([]*model.OpenMx, 0, len(s.GetQuantile())+2)
+	for _, q := range s.GetQuantile() {
+		if q == nil {
+			continue
+		}
+		om := newOpenMxWithLabels(name, ts, q.GetValue(), labels)
+		om.AddLabel("quantile", strconv.FormatFloat(q.GetQuantile(), 'g', -1, 64))
+		series = append(series, om)
+	}
+	series = append(series, newOpenMxWithLabels(name+"_sum", ts, s.GetSampleSum(), labels))
+	series = append(series, newOpenMxWithLabels(name+"_count", ts, float64(s.GetSampleCount()), labels))
+	return series
+}
+
+// convertClassicHistogram expands the explicit buckets of a classic histogram
+// into flat _bucket{le=...} series plus _sum and _count. It returns whether any
+// classic series were emitted (false for a native-only histogram with no
+// explicit buckets). The le="+Inf" bucket is synthesized when absent so the
+// output matches the text exposition, which always includes it.
+func convertClassicHistogram(name string, ts int64, h *dto.Histogram, labels []*dto.LabelPair) ([]*model.OpenMx, bool) {
+	buckets := h.GetBucket()
+	if len(buckets) == 0 {
+		return nil, false
+	}
+
+	series := make([]*model.OpenMx, 0, len(buckets)+3)
+	hasInf := false
+	for _, b := range buckets {
+		if b == nil {
+			continue
+		}
+		ub := b.GetUpperBound()
+		if math.IsInf(ub, +1) {
+			hasInf = true
+		}
+		count := float64(b.GetCumulativeCount())
+		if b.CumulativeCountFloat != nil && b.GetCumulativeCountFloat() > 0 {
+			count = b.GetCumulativeCountFloat()
+		}
+		om := newOpenMxWithLabels(name+"_bucket", ts, count, labels)
+		om.AddLabel("le", formatLE(ub))
+		series = append(series, om)
+	}
+
+	sampleCount := histogramSampleCount(h)
+	if !hasInf {
+		om := newOpenMxWithLabels(name+"_bucket", ts, sampleCount, labels)
+		om.AddLabel("le", "+Inf")
+		series = append(series, om)
+	}
+	series = append(series, newOpenMxWithLabels(name+"_sum", ts, h.GetSampleSum(), labels))
+	series = append(series, newOpenMxWithLabels(name+"_count", ts, sampleCount, labels))
+	return series, true
+}
+
+// isNativeHistogram reports whether the protobuf histogram carries native
+// (sparse, exponential) histogram data.
+func isNativeHistogram(h *dto.Histogram) bool {
+	return h.Schema != nil || len(h.GetPositiveSpan()) > 0 || len(h.GetNegativeSpan()) > 0
+}
+
+// histogramSampleCount returns the total sample count, preferring the float
+// field when present (used by native/float histograms).
+func histogramSampleCount(h *dto.Histogram) float64 {
+	if h.SampleCountFloat != nil && h.GetSampleCountFloat() > 0 {
+		return h.GetSampleCountFloat()
+	}
+	return float64(h.GetSampleCount())
+}
+
+// newOpenMxWithLabels builds an OpenMx with the supplied protobuf label pairs.
+func newOpenMxWithLabels(metric string, ts int64, value float64, labels []*dto.LabelPair) *model.OpenMx {
+	om := model.NewOpenMx(metric, ts, value)
+	for _, l := range labels {
+		if l == nil {
+			continue
+		}
+		om.AddLabel(l.GetName(), l.GetValue())
+	}
+	return om
+}
+
+// formatLE renders a histogram bucket upper bound as an `le` label value,
+// matching the Prometheus text exposition (shortest round-trippable form, with
+// "+Inf" for the catch-all bucket).
+func formatLE(upperBound float64) string {
+	if math.IsInf(upperBound, +1) {
+		return "+Inf"
+	}
+	return strconv.FormatFloat(upperBound, 'g', -1, 64)
+}
+
+// metricTypeString maps a protobuf metric type to the lowercase string used in
+// the text exposition's TYPE line (and stored in OpenMxHelp).
+func metricTypeString(t dto.MetricType) string {
+	switch t {
+	case dto.MetricType_COUNTER:
+		return "counter"
+	case dto.MetricType_GAUGE:
+		return "gauge"
+	case dto.MetricType_SUMMARY:
+		return "summary"
+	case dto.MetricType_HISTOGRAM:
+		return "histogram"
+	case dto.MetricType_GAUGE_HISTOGRAM:
+		return "gaugehistogram"
+	case dto.MetricType_UNTYPED:
+		return "untyped"
+	default:
+		return "untyped"
+	}
+}
+
+// helpMapToSlice flattens the help map, mirroring the text converter.
+func helpMapToSlice(helpMap map[string]*model.OpenMxHelp) []*model.OpenMxHelp {
+	out := make([]*model.OpenMxHelp, 0, len(helpMap))
+	for _, omh := range helpMap {
+		out = append(out, omh)
+	}
+	return out
+}

--- a/pkg/converter/protobuf_converter_test.go
+++ b/pkg/converter/protobuf_converter_test.go
@@ -1,0 +1,393 @@
+package converter
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
+
+	"open-agent/pkg/model"
+)
+
+const testTS int64 = 1_700_000_000_000
+
+func inf() float64 { return math.Inf(1) }
+
+// encodeDelimited encodes metric families as a delimited Prometheus protobuf
+// payload (the wire format negotiated via application/vnd.google.protobuf).
+func encodeDelimited(t *testing.T, families ...*dto.MetricFamily) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := expfmt.NewEncoder(&buf, expfmt.NewFormat(expfmt.TypeProtoDelim))
+	for _, mf := range families {
+		if err := enc.Encode(mf); err != nil {
+			t.Fatalf("failed to encode metric family %q: %v", mf.GetName(), err)
+		}
+	}
+	return buf.Bytes()
+}
+
+func labelPair(name, value string) *dto.LabelPair {
+	return &dto.LabelPair{Name: proto.String(name), Value: proto.String(value)}
+}
+
+// findSeries returns OpenMx entries whose metric name matches and that carry the
+// given label (key=value); pass an empty labelKey to ignore label filtering.
+func findSeries(list []*model.OpenMx, metric, labelKey, labelVal string) []*model.OpenMx {
+	var out []*model.OpenMx
+	for _, om := range list {
+		if om.Metric != metric {
+			continue
+		}
+		if labelKey == "" {
+			out = append(out, om)
+			continue
+		}
+		for _, l := range om.Labels {
+			if l.Key == labelKey && l.Value == labelVal {
+				out = append(out, om)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func mustSingle(t *testing.T, list []*model.OpenMx, metric, labelKey, labelVal string) *model.OpenMx {
+	t.Helper()
+	got := findSeries(list, metric, labelKey, labelVal)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 series for %s{%s=%s}, got %d", metric, labelKey, labelVal, len(got))
+	}
+	return got[0]
+}
+
+func labelValue(om *model.OpenMx, key string) (string, bool) {
+	for _, l := range om.Labels {
+		if l.Key == key {
+			return l.Value, true
+		}
+	}
+	return "", false
+}
+
+func TestConvertProtobuf_CounterAndGauge(t *testing.T) {
+	counter := &dto.MetricFamily{
+		Name: proto.String("http_requests_total"),
+		Help: proto.String("Total requests"),
+		Type: dto.MetricType_COUNTER.Enum(),
+		Metric: []*dto.Metric{{
+			Label:   []*dto.LabelPair{labelPair("method", "get")},
+			Counter: &dto.Counter{Value: proto.Float64(42)},
+		}},
+	}
+	gauge := &dto.MetricFamily{
+		Name: proto.String("temperature_celsius"),
+		Type: dto.MetricType_GAUGE.Enum(),
+		Metric: []*dto.Metric{{
+			Gauge: &dto.Gauge{Value: proto.Float64(21.5)},
+		}},
+	}
+
+	res, err := ConvertProtobufWithTimestamp(encodeDelimited(t, counter, gauge), testTS)
+	if err != nil {
+		t.Fatalf("ConvertProtobuf error: %v", err)
+	}
+
+	c := mustSingle(t, res.GetOpenMxList(), "http_requests_total", "method", "get")
+	if c.Value != 42 {
+		t.Errorf("counter value = %v, want 42", c.Value)
+	}
+	if c.Timestamp != testTS {
+		t.Errorf("counter timestamp = %d, want %d", c.Timestamp, testTS)
+	}
+
+	g := mustSingle(t, res.GetOpenMxList(), "temperature_celsius", "", "")
+	if g.Value != 21.5 {
+		t.Errorf("gauge value = %v, want 21.5", g.Value)
+	}
+
+	// HELP/TYPE metadata parity.
+	var counterHelp *model.OpenMxHelp
+	for _, h := range res.GetOpenMxHelpList() {
+		if h.Metric == "http_requests_total" {
+			counterHelp = h
+		}
+	}
+	if counterHelp == nil {
+		t.Fatal("expected help entry for http_requests_total")
+	}
+	if got := counterHelp.Get("type"); got != "counter" {
+		t.Errorf("type metadata = %q, want counter", got)
+	}
+	if got := counterHelp.Get("help"); got != "Total requests" {
+		t.Errorf("help metadata = %q, want 'Total requests'", got)
+	}
+}
+
+func TestConvertProtobuf_ClassicHistogram_WithExplicitInf(t *testing.T) {
+	h := &dto.MetricFamily{
+		Name: proto.String("request_duration_seconds"),
+		Type: dto.MetricType_HISTOGRAM.Enum(),
+		Metric: []*dto.Metric{{
+			Label: []*dto.LabelPair{labelPair("path", "/api")},
+			Histogram: &dto.Histogram{
+				SampleCount: proto.Uint64(12),
+				SampleSum:   proto.Float64(3.3),
+				Bucket: []*dto.Bucket{
+					{CumulativeCount: proto.Uint64(5), UpperBound: proto.Float64(0.1)},
+					{CumulativeCount: proto.Uint64(9), UpperBound: proto.Float64(0.5)},
+					{CumulativeCount: proto.Uint64(12), UpperBound: proto.Float64(inf())},
+				},
+			},
+		}},
+	}
+
+	res, err := ConvertProtobufWithTimestamp(encodeDelimited(t, h), testTS)
+	if err != nil {
+		t.Fatalf("ConvertProtobuf error: %v", err)
+	}
+	list := res.GetOpenMxList()
+
+	// Three buckets (incl. the explicit +Inf), one _sum, one _count.
+	if got := len(findSeries(list, "request_duration_seconds_bucket", "", "")); got != 3 {
+		t.Errorf("bucket series = %d, want 3 (no duplicate +Inf)", got)
+	}
+	b01 := mustSingle(t, list, "request_duration_seconds_bucket", "le", "0.1")
+	if b01.Value != 5 {
+		t.Errorf("le=0.1 bucket = %v, want 5", b01.Value)
+	}
+	if v, _ := labelValue(b01, "path"); v != "/api" {
+		t.Errorf("bucket missing original label path=/api, got %q", v)
+	}
+	bInf := mustSingle(t, list, "request_duration_seconds_bucket", "le", "+Inf")
+	if bInf.Value != 12 {
+		t.Errorf("le=+Inf bucket = %v, want 12", bInf.Value)
+	}
+	sum := mustSingle(t, list, "request_duration_seconds_sum", "", "")
+	if sum.Value != 3.3 {
+		t.Errorf("_sum = %v, want 3.3", sum.Value)
+	}
+	count := mustSingle(t, list, "request_duration_seconds_count", "", "")
+	if count.Value != 12 {
+		t.Errorf("_count = %v, want 12", count.Value)
+	}
+}
+
+func TestConvertProtobuf_ClassicHistogram_SynthesizesInf(t *testing.T) {
+	h := &dto.MetricFamily{
+		Name: proto.String("op_latency_seconds"),
+		Type: dto.MetricType_HISTOGRAM.Enum(),
+		Metric: []*dto.Metric{{
+			Histogram: &dto.Histogram{
+				SampleCount: proto.Uint64(7),
+				SampleSum:   proto.Float64(1.1),
+				Bucket: []*dto.Bucket{
+					{CumulativeCount: proto.Uint64(3), UpperBound: proto.Float64(0.25)},
+					{CumulativeCount: proto.Uint64(7), UpperBound: proto.Float64(1)},
+				},
+			},
+		}},
+	}
+
+	res, err := ConvertProtobufWithTimestamp(encodeDelimited(t, h), testTS)
+	if err != nil {
+		t.Fatalf("ConvertProtobuf error: %v", err)
+	}
+	list := res.GetOpenMxList()
+
+	// +Inf must be synthesized to match text exposition (== sample count).
+	bInf := mustSingle(t, list, "op_latency_seconds_bucket", "le", "+Inf")
+	if bInf.Value != 7 {
+		t.Errorf("synthesized le=+Inf = %v, want 7", bInf.Value)
+	}
+	if got := len(findSeries(list, "op_latency_seconds_bucket", "", "")); got != 3 {
+		t.Errorf("bucket series = %d, want 3 (2 explicit + synthesized +Inf)", got)
+	}
+}
+
+func TestConvertProtobuf_Summary(t *testing.T) {
+	s := &dto.MetricFamily{
+		Name: proto.String("rpc_duration_seconds"),
+		Type: dto.MetricType_SUMMARY.Enum(),
+		Metric: []*dto.Metric{{
+			Summary: &dto.Summary{
+				SampleCount: proto.Uint64(100),
+				SampleSum:   proto.Float64(25),
+				Quantile: []*dto.Quantile{
+					{Quantile: proto.Float64(0.5), Value: proto.Float64(0.2)},
+					{Quantile: proto.Float64(0.99), Value: proto.Float64(0.9)},
+				},
+			},
+		}},
+	}
+
+	res, err := ConvertProtobufWithTimestamp(encodeDelimited(t, s), testTS)
+	if err != nil {
+		t.Fatalf("ConvertProtobuf error: %v", err)
+	}
+	list := res.GetOpenMxList()
+
+	q50 := mustSingle(t, list, "rpc_duration_seconds", "quantile", "0.5")
+	if q50.Value != 0.2 {
+		t.Errorf("quantile 0.5 = %v, want 0.2", q50.Value)
+	}
+	q99 := mustSingle(t, list, "rpc_duration_seconds", "quantile", "0.99")
+	if q99.Value != 0.9 {
+		t.Errorf("quantile 0.99 = %v, want 0.9", q99.Value)
+	}
+	if mustSingle(t, list, "rpc_duration_seconds_sum", "", "").Value != 25 {
+		t.Error("_sum mismatch")
+	}
+	if mustSingle(t, list, "rpc_duration_seconds_count", "", "").Value != 100 {
+		t.Error("_count mismatch")
+	}
+}
+
+// TestConvertProtobuf_NativeHistogram_FieldsParsedButDeferred verifies that the
+// native histogram fields (step 3) are decoded by the protobuf path, and that
+// OpenMx emission is deferred (step 4, KAZAA-592) — i.e. no flat series for a
+// native-only histogram, and no error.
+func TestConvertProtobuf_NativeHistogram_FieldsParsedButDeferred(t *testing.T) {
+	native := &dto.Histogram{
+		SampleCount:   proto.Uint64(30),
+		SampleSum:     proto.Float64(12.5),
+		Schema:        proto.Int32(3),
+		ZeroThreshold: proto.Float64(0.001),
+		ZeroCount:     proto.Uint64(2),
+		PositiveSpan: []*dto.BucketSpan{
+			{Offset: proto.Int32(0), Length: proto.Uint32(2)},
+		},
+		PositiveDelta: []int64{4, -1},
+	}
+	mf := &dto.MetricFamily{
+		Name:   proto.String("native_latency_seconds"),
+		Type:   dto.MetricType_HISTOGRAM.Enum(),
+		Metric: []*dto.Metric{{Histogram: native}},
+	}
+
+	payload := encodeDelimited(t, mf)
+
+	// Step 3 evidence: the native fields survive the protobuf round-trip.
+	dec := expfmt.NewDecoder(bytes.NewReader(payload), expfmt.NewFormat(expfmt.TypeProtoDelim))
+	var decoded dto.MetricFamily
+	if err := dec.Decode(&decoded); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	dh := decoded.GetMetric()[0].GetHistogram()
+	if !isNativeHistogram(dh) {
+		t.Fatal("decoded histogram not detected as native")
+	}
+	if dh.GetSchema() != 3 || dh.GetZeroCount() != 2 || len(dh.GetPositiveSpan()) != 1 {
+		t.Errorf("native fields not preserved: schema=%d zeroCount=%d spans=%d",
+			dh.GetSchema(), dh.GetZeroCount(), len(dh.GetPositiveSpan()))
+	}
+	if len(dh.GetPositiveDelta()) != 2 || dh.GetPositiveDelta()[0] != 4 {
+		t.Errorf("positive deltas not preserved: %v", dh.GetPositiveDelta())
+	}
+
+	// Step 4 deferral: a native-only histogram yields no flat OpenMx series.
+	res, err := ConvertProtobufWithTimestamp(payload, testTS)
+	if err != nil {
+		t.Fatalf("ConvertProtobuf error: %v", err)
+	}
+	if got := len(res.GetOpenMxList()); got != 0 {
+		t.Errorf("native-only histogram emitted %d series, want 0 (deferred to step 4)", got)
+	}
+}
+
+// TestConvertProtobuf_DualHistogram_EmitsClassic verifies that a histogram
+// exposing BOTH classic buckets and native fields still has its classic buckets
+// collected (no regression), while the native data is deferred.
+func TestConvertProtobuf_DualHistogram_EmitsClassic(t *testing.T) {
+	dual := &dto.Histogram{
+		SampleCount:   proto.Uint64(8),
+		SampleSum:     proto.Float64(2.0),
+		Schema:        proto.Int32(2),
+		ZeroThreshold: proto.Float64(0.001),
+		PositiveSpan:  []*dto.BucketSpan{{Offset: proto.Int32(0), Length: proto.Uint32(1)}},
+		PositiveDelta: []int64{8},
+		Bucket: []*dto.Bucket{
+			{CumulativeCount: proto.Uint64(4), UpperBound: proto.Float64(0.5)},
+			{CumulativeCount: proto.Uint64(8), UpperBound: proto.Float64(inf())},
+		},
+	}
+	mf := &dto.MetricFamily{
+		Name:   proto.String("dual_seconds"),
+		Type:   dto.MetricType_HISTOGRAM.Enum(),
+		Metric: []*dto.Metric{{Histogram: dual}},
+	}
+
+	res, err := ConvertProtobufWithTimestamp(encodeDelimited(t, mf), testTS)
+	if err != nil {
+		t.Fatalf("ConvertProtobuf error: %v", err)
+	}
+	list := res.GetOpenMxList()
+	if got := len(findSeries(list, "dual_seconds_bucket", "", "")); got != 2 {
+		t.Errorf("classic buckets = %d, want 2", got)
+	}
+	if mustSingle(t, list, "dual_seconds_count", "", "").Value != 8 {
+		t.Error("dual histogram _count mismatch")
+	}
+}
+
+func TestConvertWithContentType_TextFallback(t *testing.T) {
+	text := "# HELP foo A foo\n# TYPE foo counter\nfoo{a=\"b\"} 7\n"
+	res, err := ConvertWithContentType([]byte(text), "text/plain; version=0.0.4", testTS)
+	if err != nil {
+		t.Fatalf("text fallback error: %v", err)
+	}
+	om := mustSingle(t, res.GetOpenMxList(), "foo", "a", "b")
+	if om.Value != 7 {
+		t.Errorf("text fallback value = %v, want 7", om.Value)
+	}
+}
+
+func TestConvertWithContentType_ProtobufRouting(t *testing.T) {
+	mf := &dto.MetricFamily{
+		Name:   proto.String("up"),
+		Type:   dto.MetricType_GAUGE.Enum(),
+		Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: proto.Float64(1)}}},
+	}
+	ct := "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
+	res, err := ConvertWithContentType(encodeDelimited(t, mf), ct, testTS)
+	if err != nil {
+		t.Fatalf("protobuf routing error: %v", err)
+	}
+	if mustSingle(t, res.GetOpenMxList(), "up", "", "").Value != 1 {
+		t.Error("protobuf-routed gauge mismatch")
+	}
+}
+
+func TestIsProtobufContentType(t *testing.T) {
+	cases := map[string]bool{
+		"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited": true,
+		"application/vnd.google.protobuf; encoding=delimited":                                        true,
+		"text/plain; version=0.0.4":                   false,
+		"application/openmetrics-text; version=1.0.0": false,
+		"": false,
+	}
+	for ct, want := range cases {
+		if got := IsProtobufContentType(ct); got != want {
+			t.Errorf("IsProtobufContentType(%q) = %v, want %v", ct, got, want)
+		}
+	}
+}
+
+func TestFormatLE(t *testing.T) {
+	cases := map[float64]string{
+		0.1:   "0.1",
+		1:     "1",
+		2.5:   "2.5",
+		inf(): "+Inf",
+		0.005: "0.005",
+	}
+	for in, want := range cases {
+		if got := formatLE(in); got != want {
+			t.Errorf("formatLE(%v) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/model/scrape_raw_data.go
+++ b/pkg/model/scrape_raw_data.go
@@ -4,6 +4,7 @@ package model
 type ScrapeRawData struct {
 	TargetURL            string
 	RawData              string
+	ContentType          string // Response Content-Type, used to select the protobuf vs. text decoder
 	MetricRelabelConfigs RelabelConfigs
 	Labels               map[string]string // Target labels
 	NodeName             string

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -81,8 +81,10 @@ func (p *Processor) processRawData(rawData *model.ScrapeRawData) {
 		}
 	}
 
-	// Convert the raw data to OpenMx format using the collection timestamp
-	conversionResult, err := converter.ConvertWithTimestamp(rawData.RawData, rawData.CollectionTime)
+	// Convert the raw data to OpenMx format using the collection timestamp.
+	// The decoder (protobuf vs. text) is selected from the response Content-Type;
+	// non-protobuf payloads fall back to the existing text parser.
+	conversionResult, err := converter.ConvertWithContentType([]byte(rawData.RawData), rawData.ContentType, rawData.CollectionTime)
 	if err != nil {
 		logutil.Errorf("PROCESSOR", "Error converting raw data: %v", err)
 		return

--- a/pkg/scraper/scraper_task.go
+++ b/pkg/scraper/scraper_task.go
@@ -274,10 +274,11 @@ func (st *ScraperTask) Run() (*model.ScrapeRawData, error) {
 
 	// Execute the HTTP request
 	httpClient := client.GetInstance()
-	var response string
+	var responseBytes []byte
+	var contentType string
 	var httpErr error
 
-	response, httpErr = httpClient.ExecuteGetWithAuth(formattedURL, st.TLSConfig, st.BasicAuth, timeout)
+	responseBytes, contentType, httpErr = httpClient.ExecuteGetWithAuthResponse(formattedURL, st.TLSConfig, st.BasicAuth, timeout)
 
 	if httpErr != nil {
 		logutil.Infof("SCRAPER", "Failed to collect from target [%s]: %v", st.TargetName, httpErr)
@@ -287,6 +288,10 @@ func (st *ScraperTask) Run() (*model.ScrapeRawData, error) {
 		return nil, fmt.Errorf("error scraping target %s for target %s: %v", targetURL, st.TargetName, httpErr)
 	}
 
+	// The response body may be binary (protobuf) or text exposition. It is kept
+	// as a string for transport; the processor selects the decoder via ContentType.
+	response := string(responseBytes)
+
 	// Create a ScrapeRawData instance with the response
 	var rawData *model.ScrapeRawData
 	if st.NodeName != "" && st.AddNodeLabel {
@@ -294,6 +299,7 @@ func (st *ScraperTask) Run() (*model.ScrapeRawData, error) {
 	} else {
 		rawData = model.NewScrapeRawData(targetURL, response, st.MetricRelabelConfigs, st.Labels, collectionTime)
 	}
+	rawData.ContentType = contentType
 
 	// Log detailed information
 	duration := time.Since(startTime)
@@ -309,19 +315,28 @@ func (st *ScraperTask) Run() (*model.ScrapeRawData, error) {
 		logutil.Debugf("SCRAPER", "Response preview: %s", preview)
 	}
 
-	// Count the number of metrics in the response (approximate)
+	// Count the number of metrics in the response (approximate). Line counting
+	// only makes sense for the text exposition; protobuf bodies are binary.
+	isProtobuf := strings.HasPrefix(contentType, "application/vnd.google.protobuf")
 	metricCount := 0
-	for _, line := range strings.Split(response, "\n") {
-		// Skip empty lines, comments, and metadata lines
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
+	if !isProtobuf {
+		for _, line := range strings.Split(response, "\n") {
+			// Skip empty lines, comments, and metadata lines
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			metricCount++
 		}
-		metricCount++
 	}
 
 	// Log collection success with essential information at INFO level
-	logutil.Infof("SCRAPER", "Successfully collected from target [%s]: %d metrics, %d bytes, took %v",
-		st.TargetName, metricCount, len(response), duration)
+	if isProtobuf {
+		logutil.Infof("SCRAPER", "Successfully collected from target [%s]: protobuf payload, %d bytes, took %v",
+			st.TargetName, len(response), duration)
+	} else {
+		logutil.Infof("SCRAPER", "Successfully collected from target [%s]: %d metrics, %d bytes, took %v",
+			st.TargetName, metricCount, len(response), duration)
+	}
 
 	// Keep detailed debug information
 	if config.IsDebugEnabled() {


### PR DESCRIPTION
## 개요

[KAZAA-585] 호환성 검토 / [KAZAA-586] 코드 감사에서 확인된 구조적 제약(`Accept: application/json` 고정 → native histogram 수집 불가)을 해소하기 위해, 오픈에이전트에 **Prometheus protobuf 스크랩(content negotiation + 디코딩)** 을 도입한다.

KAZAA-591 의 4단계 중 **step 1~3(content negotiation, protobuf 디코딩, native histogram 필드 파싱)** 을 구현했다. **step 4(native histogram → OpenMx 변환)** 는 OpenMx 스키마 설계(**KAZAA-592**, in progress)에 의존하므로 본 PR 범위에서 제외하고, 디코딩된 native histogram 은 안전하게 보류(skip + 로그)한다.

> ⚠️ 이슈 본문은 선행 조건을 `KAZAA-590` 으로 적었으나, 실제 OpenMx 스키마 설계 이슈는 번호가 이동한 **KAZAA-592** 입니다. (KAZAA-590 은 무관한 ask-k8s-team 트리아지 이슈)

## 변경 사항

### 1. Content Negotiation (`pkg/client/http_client.go`)
- `ExecuteGetWithAuthResponse()` 신설: 응답 본문(`[]byte`) + `Content-Type` 반환. 기존 `ExecuteGetWithAuth()`(string)는 이를 감싸는 wrapper 로 유지(기존 호출부 무영향).
- `openagent_enable_protobuf` 플래그(기본 `false`)가 켜지면 우선순위 Accept 헤더 광고:
  `application/vnd.google.protobuf;...;encoding=delimited, application/openmetrics-text;..., text/plain;..., */*;q=0.1`
  꺼져 있으면 기존 `application/json` 그대로 → **기본 동작 완전 불변**.

### 2. Protobuf 디코딩 (`pkg/converter/protobuf_converter.go`)
- `prometheus/common/expfmt` + `prometheus/client_model/go` 로 delimited protobuf 디코딩.
- `ConvertWithContentType()` 가 응답 `Content-Type` 으로 protobuf/text 디코더를 분기. 비-protobuf 는 기존 text 파서로 폴백.

### 3. Classic 타입 변환 (regression-free)
- counter / gauge / untyped / summary / classic histogram 을 **기존 text 파서와 동일한 flat 시리즈**로 변환.
- histogram: `_bucket{le=...}` + `_sum` + `_count`. protobuf 에서 `le="+Inf"` 버킷이 없으면 sample count 로 **합성**(text 노출과 일치).

### 4. Native histogram 필드 파싱 / 보류
- `Schema`, `ZeroThreshold`, `ZeroCount`, `PositiveSpan/Delta`, `NegativeSpan/Delta` 가 protobuf 디코딩으로 파싱됨(step 3).
- OpenMx 변환은 **KAZAA-592 스키마 확정 후(step 4)** 진행 → 현재는 skip + 로그.
- classic 버킷을 함께 노출하는 dual histogram 은 classic 버킷을 정상 수집(regression 없음).

### 5. 배관 / 문서
- `model.ScrapeRawData.ContentType` 추가, `pkg/processor` 가 이를 기반으로 디코더 선택.
- `pkg/scraper` 가 새 응답 메서드 사용 + protobuf 본문에 대한 로그 라인 정리.
- README 에 `openagent_enable_protobuf` 선택 설정 문서화.

## 테스트
`pkg/converter/protobuf_converter_test.go` 신규:
- counter/gauge + HELP/TYPE 메타 parity
- classic histogram (명시적 +Inf / +Inf 합성)
- summary (quantile/_sum/_count)
- native-only histogram → 필드 round-trip 검증 + flat 시리즈 0개(보류)
- dual histogram → classic 버킷 정상 수집
- content-type 라우팅(protobuf/text), `IsProtobufContentType`, `formatLE`

검증 결과:
```
go build ./pkg/...                 # OK
go vet  ./pkg/{converter,client,scraper,processor,model}/...   # OK
go test ./pkg/converter/...        # ok
gofmt -l (변경 파일)               # clean
```
> 참고: `util/*`(npmagent 의존, linux-only afpacket)와 `pkg/sender` 테스트(stale `NewSender` 시그니처)는 **본 변경과 무관하게 master 에서도 동일하게 실패**하는 기존 상태입니다.

## 의존성
- `github.com/prometheus/client_model v0.6.1`
- `github.com/prometheus/common v0.55.0`
- `google.golang.org/protobuf` indirect → direct (v1.35.2)

## 후속
- **KAZAA-591 step 4**: native histogram → OpenMx 변환 (블로커: **KAZAA-592** OpenMx 스키마 설계)

Refs: KAZAA-591, KAZAA-585, KAZAA-586, KAZAA-592
