### PR TITLE
[KAZAA-593] OpenMxHistogramPack pack type 0x1605 → 0x1607 수정

### DIFF
--- a/pkg/model/open_mx_histogram_pack.go
+++ b/pkg/model/open_mx_histogram_pack.go
@@ -8,12 +8,11 @@ import (
 
 // Pack type constant for OpenMxHistogramPack.
 //
-// NOTE: 0x1605 is the next free value after OPEN_MX_PACK (0x1603) and
-// OPEN_MX_HELP_PACK (0x1604). The final number MUST be confirmed with the
-// WhaTap collection-server team so it does not collide with any pack type
-// already registered server-side (see KAZAA-592 design doc, server coordination).
+// 0x1605 was initially proposed but is already used server-side as TAG_META.
+// 0x1606 is OPEN_MX_ENDPOINT_PACK.
+// 0x1607 is the confirmed next available value (coordinated via KAZAA-593).
 const (
-	OPEN_MX_HISTOGRAM_PACK = 0x1605
+	OPEN_MX_HISTOGRAM_PACK = 0x1607
 )
 
 // OpenMxHistogramPack represents a pack of OpenMxHistogram records for sending


### PR DESCRIPTION
## 변경 요약

`0x1605`는 서버 측 `PackEnum.java`에서 `TAG_META`로 이미 등록되어 있어 충돌.

- `0x1606` = `OPEN_MX_ENDPOINT_PACK` (기존 사용)
- **`0x1607`로 변경 확정** (KAZAA-593 서버팀 협의)

## 변경 내용

- `pkg/model/open_mx_histogram_pack.go`: `OPEN_MX_HISTOGRAM_PACK = 0x1605` → `0x1607`

## 테스트

```
go test ./pkg/model/ -run TestOpenMxHistogram -v → PASS (4개 케스)
```

## 관련

- KAZAA-593: Pack 번호 협의
- KAZAA-592: 설계 문서
- apm 서버 대응 PR: https://github.com/whatap/apm/pull/1357