### PR TITLE
[KAZAA-595] Native Histogram → OpenMxHistogram 변환 구현 (KAZAA-591 step 4)

### DIFF
--- a/pkg/converter/protobuf_converter.go
+++ b/pkg/converter/protobuf_converter.go
@@ -52,25 +52,31 @@ func ConvertProtobuf(data []byte) (*model.ConversionResult, error) {
 
 // ConvertProtobufWithTimestamp decodes a delimited Prometheus protobuf payload
 // (Content-Type: application/vnd.google.protobuf; encoding=delimited) into the
-// OpenMx flat-series representation.
+// OpenMx representation.
 //
 // Classic metric types (counter, gauge, summary, untyped and classic
 // histograms with explicit buckets) are converted to exactly the same flat
 // series the text parser produces, so switching a target to protobuf does not
 // change collected classic metrics.
 //
-// Native (sparse) histograms are structurally decoded here — the Schema, zero
-// bucket, positive/negative spans and deltas are all parsed by the protobuf
-// decoder — but their conversion into the native OpenMx structure is deferred to
-// KAZAA-591 step 4, which depends on the OpenMx schema design in KAZAA-592. For
-// now native histogram series are skipped (their classic buckets, if the target
-// exposes them alongside, are still collected normally).
+// Native (sparse) histograms are converted into model.OpenMxHistogram records
+// (the schema confirmed in KAZAA-592 — Option B, a sibling type that leaves the
+// scalar OpenMx wire format untouched) and returned on the result's
+// OpenMxHistogramList. The confirmed schema carries integer, delta-encoded
+// buckets and uint64 counts, so standard (counter-derived) integer native
+// histograms convert losslessly. Float native histograms (gauge histograms and
+// values produced by float operations, which carry absolute float bucket
+// counts) cannot be represented by that schema and are skipped with a count
+// (see the summary log below). If a target exposes classic buckets alongside a
+// native histogram, those classic series are still collected normally.
 func ConvertProtobufWithTimestamp(data []byte, collectionTime int64) (*model.ConversionResult, error) {
 	openMxList := make([]*model.OpenMx, 0)
+	histogramList := make([]*model.OpenMxHistogram, 0)
 	helpMap := make(map[string]*model.OpenMxHelp)
 
 	dec := expfmt.NewDecoder(bytes.NewReader(data), expfmt.NewFormat(expfmt.TypeProtoDelim))
 	nativeHistogramCount := 0
+	floatNativeSkipped := 0
 
 	for {
 		var mf dto.MetricFamily
@@ -81,8 +87,9 @@ func ConvertProtobufWithTimestamp(data []byte, collectionTime int64) (*model.Con
 		if err != nil {
 			// Surface the error but keep the families decoded so far: a malformed
 			// tail should not silently discard valid leading metrics.
-			return model.NewConversionResult(openMxList, helpMapToSlice(helpMap)),
-				fmt.Errorf("error decoding protobuf metric family: %v", err)
+			partial := model.NewConversionResult(openMxList, helpMapToSlice(helpMap))
+			partial.SetOpenMxHistogramList(histogramList)
+			return partial, fmt.Errorf("error decoding protobuf metric family: %v", err)
 		}
 
 		name := mf.GetName()
@@ -132,29 +139,44 @@ func ConvertProtobufWithTimestamp(data []byte, collectionTime int64) (*model.Con
 					continue
 				}
 				// Classic buckets first — preserves exact flat-series behavior.
-				series, classicEmitted := convertClassicHistogram(name, ts, h, labels)
+				series, _ := convertClassicHistogram(name, ts, h, labels)
 				openMxList = append(openMxList, series...)
 
-				// Native histogram: decoded but emission deferred (see doc comment).
+				// Native histogram: convert into the dedicated OpenMxHistogram
+				// structure (KAZAA-592 schema). Classic buckets (above) and the
+				// native histogram are independent representations of the same
+				// metric, so a target exposing both yields both forms.
 				if isNativeHistogram(h) {
 					nativeHistogramCount++
-					if !classicEmitted && configPkg.IsDebugEnabled() {
-						logutil.Debugf("CONVERTER",
-							"[CONVERTER] Native histogram %q decoded (schema=%d) but OpenMx emission deferred (KAZAA-591 step 4)",
-							name, h.GetSchema())
+					if omh, ok := convertNativeHistogram(name, ts, h, labels); ok {
+						histogramList = append(histogramList, omh)
+					} else {
+						// Float native histogram: outside the confirmed integer
+						// schema. Skipped, but counted and surfaced below.
+						floatNativeSkipped++
+						if configPkg.IsDebugEnabled() {
+							logutil.Debugf("CONVERTER",
+								"[CONVERTER] Float native histogram %q (schema=%d) skipped: not representable by the integer OpenMxHistogram schema (KAZAA-592)",
+								name, h.GetSchema())
+						}
 					}
 				}
 			}
 		}
 	}
 
-	if nativeHistogramCount > 0 {
+	if floatNativeSkipped > 0 {
 		logutil.Infof("CONVERTER",
-			"Decoded %d native histogram metric(s) from protobuf; native OpenMx conversion is pending (KAZAA-591 step 4 / KAZAA-592). Classic buckets, where exposed alongside, were collected normally.",
-			nativeHistogramCount)
+			"Converted %d native histogram metric(s) to OpenMxHistogram; %d float native histogram(s) skipped (not representable by the integer OpenMxHistogram schema, KAZAA-592). Classic buckets, where exposed alongside, were collected normally.",
+			nativeHistogramCount-floatNativeSkipped, floatNativeSkipped)
+	} else if nativeHistogramCount > 0 {
+		logutil.Debugf("CONVERTER",
+			"Converted %d native histogram metric(s) to OpenMxHistogram.", nativeHistogramCount)
 	}
 
-	return model.NewConversionResult(openMxList, helpMapToSlice(helpMap)), nil
+	result := model.NewConversionResult(openMxList, helpMapToSlice(helpMap))
+	result.SetOpenMxHistogramList(histogramList)
+	return result, nil
 }
 
 // convertSummary expands a summary into its flat series: one series per quantile
@@ -219,6 +241,77 @@ func convertClassicHistogram(name string, ts int64, h *dto.Histogram, labels []*
 // (sparse, exponential) histogram data.
 func isNativeHistogram(h *dto.Histogram) bool {
 	return h.Schema != nil || len(h.GetPositiveSpan()) > 0 || len(h.GetNegativeSpan()) > 0
+}
+
+// isFloatNativeHistogram reports whether the native histogram carries absolute
+// float bucket counts (PositiveCount/NegativeCount, *Float counts) instead of
+// integer, delta-encoded buckets. These arise from gauge histograms and float
+// operations and cannot be represented by the integer OpenMxHistogram schema
+// (KAZAA-592), so the converter skips them rather than emitting lossy data.
+func isFloatNativeHistogram(h *dto.Histogram) bool {
+	return len(h.GetPositiveCount()) > 0 || len(h.GetNegativeCount()) > 0 ||
+		h.SampleCountFloat != nil || h.ZeroCountFloat != nil
+}
+
+// convertNativeHistogram converts a protobuf native (sparse) histogram into the
+// OpenMxHistogram structure confirmed in KAZAA-592. It returns ok=false for
+// float native histograms, which the integer schema cannot represent.
+//
+// Bucket counts are carried verbatim as the protobuf delta encoding (the first
+// entry of each span list is an absolute count, each subsequent entry is the
+// delta from its predecessor); the schema and OpenMxHistogram both preserve
+// this encoding, so no decode/re-encode of the bucket deltas is performed here.
+func convertNativeHistogram(name string, ts int64, h *dto.Histogram, labels []*dto.LabelPair) (*model.OpenMxHistogram, bool) {
+	if isFloatNativeHistogram(h) {
+		return nil, false
+	}
+
+	omh := model.NewOpenMxHistogram(name, ts)
+	for _, l := range labels {
+		if l == nil {
+			continue
+		}
+		omh.AddLabel(l.GetName(), l.GetValue())
+	}
+
+	omh.Data = model.NativeHistogramData{
+		Schema:          h.GetSchema(),
+		ZeroThreshold:   h.GetZeroThreshold(),
+		ZeroCount:       h.GetZeroCount(),
+		Count:           h.GetSampleCount(),
+		Sum:             h.GetSampleSum(),
+		PositiveSpans:   convertBucketSpans(h.GetPositiveSpan()),
+		PositiveBuckets: copyInt64Slice(h.GetPositiveDelta()),
+		NegativeSpans:   convertBucketSpans(h.GetNegativeSpan()),
+		NegativeBuckets: copyInt64Slice(h.GetNegativeDelta()),
+	}
+	return omh, true
+}
+
+// convertBucketSpans maps protobuf BucketSpans to the model representation.
+func convertBucketSpans(spans []*dto.BucketSpan) []model.BucketSpan {
+	if len(spans) == 0 {
+		return nil
+	}
+	out := make([]model.BucketSpan, 0, len(spans))
+	for _, s := range spans {
+		if s == nil {
+			continue
+		}
+		out = append(out, model.BucketSpan{Offset: s.GetOffset(), Length: s.GetLength()})
+	}
+	return out
+}
+
+// copyInt64Slice returns a defensive copy so the OpenMxHistogram does not alias
+// memory owned by the protobuf decoder.
+func copyInt64Slice(in []int64) []int64 {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]int64, len(in))
+	copy(out, in)
+	return out
 }
 
 // histogramSampleCount returns the total sample count, preferring the float

--- a/pkg/converter/protobuf_converter_test.go
+++ b/pkg/converter/protobuf_converter_test.go
@@ -247,11 +247,40 @@ func TestConvertProtobuf_Summary(t *testing.T) {
 	}
 }
 
-// TestConvertProtobuf_NativeHistogram_FieldsParsedButDeferred verifies that the
-// native histogram fields (step 3) are decoded by the protobuf path, and that
-// OpenMx emission is deferred (step 4, KAZAA-592) — i.e. no flat series for a
-// native-only histogram, and no error.
-func TestConvertProtobuf_NativeHistogram_FieldsParsedButDeferred(t *testing.T) {
+// findHistogram returns OpenMxHistogram records whose metric name matches.
+func findHistogram(list []*model.OpenMxHistogram, metric string) []*model.OpenMxHistogram {
+	var out []*model.OpenMxHistogram
+	for _, h := range list {
+		if h.Metric == metric {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func mustSingleHistogram(t *testing.T, list []*model.OpenMxHistogram, metric string) *model.OpenMxHistogram {
+	t.Helper()
+	got := findHistogram(list, metric)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 histogram for %s, got %d", metric, len(got))
+	}
+	return got[0]
+}
+
+func histogramLabel(h *model.OpenMxHistogram, key string) (string, bool) {
+	for _, l := range h.Labels {
+		if l.Key == key {
+			return l.Value, true
+		}
+	}
+	return "", false
+}
+
+// TestConvertProtobuf_NativeHistogram_IntegerConversion verifies step 4: an
+// integer native (sparse) histogram is converted into an OpenMxHistogram with
+// every field mapped per the KAZAA-592 schema, and that it does NOT leak into
+// the flat OpenMx series list (native-only histogram → no classic series).
+func TestConvertProtobuf_NativeHistogram_IntegerConversion(t *testing.T) {
 	native := &dto.Histogram{
 		SampleCount:   proto.Uint64(30),
 		SampleSum:     proto.Float64(12.5),
@@ -262,47 +291,68 @@ func TestConvertProtobuf_NativeHistogram_FieldsParsedButDeferred(t *testing.T) {
 			{Offset: proto.Int32(0), Length: proto.Uint32(2)},
 		},
 		PositiveDelta: []int64{4, -1},
+		NegativeSpan: []*dto.BucketSpan{
+			{Offset: proto.Int32(-1), Length: proto.Uint32(1)},
+		},
+		NegativeDelta: []int64{3},
 	}
 	mf := &dto.MetricFamily{
 		Name:   proto.String("native_latency_seconds"),
 		Type:   dto.MetricType_HISTOGRAM.Enum(),
-		Metric: []*dto.Metric{{Histogram: native}},
+		Metric: []*dto.Metric{{Label: []*dto.LabelPair{labelPair("path", "/api")}, Histogram: native}},
 	}
 
-	payload := encodeDelimited(t, mf)
-
-	// Step 3 evidence: the native fields survive the protobuf round-trip.
-	dec := expfmt.NewDecoder(bytes.NewReader(payload), expfmt.NewFormat(expfmt.TypeProtoDelim))
-	var decoded dto.MetricFamily
-	if err := dec.Decode(&decoded); err != nil {
-		t.Fatalf("decode error: %v", err)
-	}
-	dh := decoded.GetMetric()[0].GetHistogram()
-	if !isNativeHistogram(dh) {
-		t.Fatal("decoded histogram not detected as native")
-	}
-	if dh.GetSchema() != 3 || dh.GetZeroCount() != 2 || len(dh.GetPositiveSpan()) != 1 {
-		t.Errorf("native fields not preserved: schema=%d zeroCount=%d spans=%d",
-			dh.GetSchema(), dh.GetZeroCount(), len(dh.GetPositiveSpan()))
-	}
-	if len(dh.GetPositiveDelta()) != 2 || dh.GetPositiveDelta()[0] != 4 {
-		t.Errorf("positive deltas not preserved: %v", dh.GetPositiveDelta())
-	}
-
-	// Step 4 deferral: a native-only histogram yields no flat OpenMx series.
-	res, err := ConvertProtobufWithTimestamp(payload, testTS)
+	res, err := ConvertProtobufWithTimestamp(encodeDelimited(t, mf), testTS)
 	if err != nil {
 		t.Fatalf("ConvertProtobuf error: %v", err)
 	}
+
+	// Native-only histogram emits no flat OpenMx series.
 	if got := len(res.GetOpenMxList()); got != 0 {
-		t.Errorf("native-only histogram emitted %d series, want 0 (deferred to step 4)", got)
+		t.Errorf("native-only histogram emitted %d flat series, want 0", got)
+	}
+
+	h := mustSingleHistogram(t, res.GetOpenMxHistogramList(), "native_latency_seconds")
+	if h.Timestamp != testTS {
+		t.Errorf("histogram timestamp = %d, want %d", h.Timestamp, testTS)
+	}
+	if v, _ := histogramLabel(h, "path"); v != "/api" {
+		t.Errorf("histogram missing original label path=/api, got %q", v)
+	}
+	d := h.Data
+	if d.Schema != 3 {
+		t.Errorf("Schema = %d, want 3", d.Schema)
+	}
+	if d.ZeroThreshold != 0.001 {
+		t.Errorf("ZeroThreshold = %v, want 0.001", d.ZeroThreshold)
+	}
+	if d.ZeroCount != 2 {
+		t.Errorf("ZeroCount = %d, want 2", d.ZeroCount)
+	}
+	if d.Count != 30 {
+		t.Errorf("Count = %d, want 30", d.Count)
+	}
+	if d.Sum != 12.5 {
+		t.Errorf("Sum = %v, want 12.5", d.Sum)
+	}
+	if len(d.PositiveSpans) != 1 || d.PositiveSpans[0].Offset != 0 || d.PositiveSpans[0].Length != 2 {
+		t.Errorf("PositiveSpans = %+v, want [{0 2}]", d.PositiveSpans)
+	}
+	if len(d.PositiveBuckets) != 2 || d.PositiveBuckets[0] != 4 || d.PositiveBuckets[1] != -1 {
+		t.Errorf("PositiveBuckets = %v, want [4 -1] (delta-encoded, verbatim)", d.PositiveBuckets)
+	}
+	if len(d.NegativeSpans) != 1 || d.NegativeSpans[0].Offset != -1 || d.NegativeSpans[0].Length != 1 {
+		t.Errorf("NegativeSpans = %+v, want [{-1 1}]", d.NegativeSpans)
+	}
+	if len(d.NegativeBuckets) != 1 || d.NegativeBuckets[0] != 3 {
+		t.Errorf("NegativeBuckets = %v, want [3]", d.NegativeBuckets)
 	}
 }
 
-// TestConvertProtobuf_DualHistogram_EmitsClassic verifies that a histogram
-// exposing BOTH classic buckets and native fields still has its classic buckets
-// collected (no regression), while the native data is deferred.
-func TestConvertProtobuf_DualHistogram_EmitsClassic(t *testing.T) {
+// TestConvertProtobuf_DualHistogram_EmitsBoth verifies that a histogram exposing
+// BOTH classic buckets and native fields yields the classic flat series (no
+// regression) AND an OpenMxHistogram for the native data.
+func TestConvertProtobuf_DualHistogram_EmitsBoth(t *testing.T) {
 	dual := &dto.Histogram{
 		SampleCount:   proto.Uint64(8),
 		SampleSum:     proto.Float64(2.0),
@@ -331,6 +381,51 @@ func TestConvertProtobuf_DualHistogram_EmitsClassic(t *testing.T) {
 	}
 	if mustSingle(t, list, "dual_seconds_count", "", "").Value != 8 {
 		t.Error("dual histogram _count mismatch")
+	}
+
+	// Native data is also emitted as an OpenMxHistogram.
+	h := mustSingleHistogram(t, res.GetOpenMxHistogramList(), "dual_seconds")
+	if h.Data.Schema != 2 || h.Data.Count != 8 {
+		t.Errorf("native part: schema=%d count=%d, want schema=2 count=8", h.Data.Schema, h.Data.Count)
+	}
+	if len(h.Data.PositiveBuckets) != 1 || h.Data.PositiveBuckets[0] != 8 {
+		t.Errorf("native PositiveBuckets = %v, want [8]", h.Data.PositiveBuckets)
+	}
+}
+
+// TestConvertProtobuf_FloatNativeHistogram_Skipped verifies that a float native
+// histogram (absolute float bucket counts) is skipped — not representable by the
+// integer OpenMxHistogram schema (KAZAA-592) — without emitting a histogram or
+// erroring. A target exposing classic buckets alongside still gets those.
+func TestConvertProtobuf_FloatNativeHistogram_Skipped(t *testing.T) {
+	floatNative := &dto.Histogram{
+		SampleCountFloat: proto.Float64(9.0),
+		SampleSum:        proto.Float64(4.0),
+		Schema:           proto.Int32(1),
+		ZeroThreshold:    proto.Float64(0.001),
+		ZeroCountFloat:   proto.Float64(1.0),
+		PositiveSpan:     []*dto.BucketSpan{{Offset: proto.Int32(0), Length: proto.Uint32(2)}},
+		PositiveCount:    []float64{3.0, 5.0}, // absolute float counts → float histogram
+		Bucket: []*dto.Bucket{
+			{CumulativeCount: proto.Uint64(9), UpperBound: proto.Float64(inf())},
+		},
+	}
+	mf := &dto.MetricFamily{
+		Name:   proto.String("float_native_seconds"),
+		Type:   dto.MetricType_GAUGE_HISTOGRAM.Enum(),
+		Metric: []*dto.Metric{{Histogram: floatNative}},
+	}
+
+	res, err := ConvertProtobufWithTimestamp(encodeDelimited(t, mf), testTS)
+	if err != nil {
+		t.Fatalf("ConvertProtobuf error: %v", err)
+	}
+	if got := len(findHistogram(res.GetOpenMxHistogramList(), "float_native_seconds")); got != 0 {
+		t.Errorf("float native histogram emitted %d OpenMxHistogram(s), want 0 (skipped)", got)
+	}
+	// Classic +Inf bucket exposed alongside is still collected.
+	if got := len(findSeries(res.GetOpenMxList(), "float_native_seconds_bucket", "", "")); got != 1 {
+		t.Errorf("classic bucket alongside float native = %d, want 1", got)
 	}
 }
 

--- a/pkg/model/conversion_result.go
+++ b/pkg/model/conversion_result.go
@@ -4,8 +4,12 @@ package model
 type ConversionResult struct {
 	OpenMxList     []*OpenMx
 	OpenMxHelpList []*OpenMxHelp
-	Target         string
-	CollectionTime int64
+	// OpenMxHistogramList carries Native (sparse) Histogram samples decoded from
+	// the protobuf exposition format. It is nil for text/OpenMetrics scrapes,
+	// which cannot express native histograms (KAZAA-591 step 4 / KAZAA-592).
+	OpenMxHistogramList []*OpenMxHistogram
+	Target              string
+	CollectionTime      int64
 }
 
 // NewConversionResult creates a new ConversionResult instance
@@ -24,6 +28,16 @@ func (cr *ConversionResult) GetOpenMxList() []*OpenMx {
 // GetOpenMxHelpList returns the list of OpenMxHelp instances
 func (cr *ConversionResult) GetOpenMxHelpList() []*OpenMxHelp {
 	return cr.OpenMxHelpList
+}
+
+// GetOpenMxHistogramList returns the list of Native Histogram samples.
+func (cr *ConversionResult) GetOpenMxHistogramList() []*OpenMxHistogram {
+	return cr.OpenMxHistogramList
+}
+
+// SetOpenMxHistogramList sets the list of Native Histogram samples.
+func (cr *ConversionResult) SetOpenMxHistogramList(list []*OpenMxHistogram) {
+	cr.OpenMxHistogramList = list
 }
 
 // GetTarget returns the target

--- a/pkg/model/open_mx_histogram_pack.go
+++ b/pkg/model/open_mx_histogram_pack.go
@@ -8,12 +8,11 @@ import (
 
 // Pack type constant for OpenMxHistogramPack.
 //
-// NOTE: 0x1605 is the next free value after OPEN_MX_PACK (0x1603) and
-// OPEN_MX_HELP_PACK (0x1604). The final number MUST be confirmed with the
-// WhaTap collection-server team so it does not collide with any pack type
-// already registered server-side (see KAZAA-592 design doc, server coordination).
+// 0x1605 was initially proposed but is already used server-side as TAG_META.
+// 0x1606 is OPEN_MX_ENDPOINT_PACK.
+// 0x1607 is the confirmed next available value (coordinated via KAZAA-593).
 const (
-	OPEN_MX_HISTOGRAM_PACK = 0x1605
+	OPEN_MX_HISTOGRAM_PACK = 0x1607
 )
 
 // OpenMxHistogramPack represents a pack of OpenMxHistogram records for sending


### PR DESCRIPTION
## 개요

KAZAA-591 step 4 — protobuf 로 디코딩된 native(sparse) histogram 을 **KAZAA-592 확정 스키마**(`OpenMxHistogram`, Option B)로 변환한다. 기존 `protobuf_converter.go` 의 native histogram **skip+로그** 분기를 실제 변환으로 교체.

## 스택(의존) — 머지 순서 주의 ⚠️

이 브랜치는 아직 master 에 머지되지 않은 두 PR 위에 쌓여 있습니다. 본 PR 의 **net-new 커밋은 `9ed134d` 하나**이며, 나머지는 아래 PR 의 커밋입니다.

- **#19 / KAZAA-592** — `OpenMxHistogram`/`NativeHistogramData`/`BucketSpan` 타입 + `OpenMxHistogramPack` (변환 대상 스키마)
- **KAZAA-593** — 위 Pack 타입 번호 `0x1605 → 0x1607` 수정 (서버 PackEnum 충돌 회피, `0x1605`=TAG_META / `0x1606`=OPEN_MX_ENDPOINT_PACK)
- **#20 / KAZAA-591 step 1~3** — content negotiation, protobuf 디코딩, native 필드 파싱 (이 PR 의 base 코드)

권장 머지 순서: **#19(+KAZAA-593) → #20 → 본 PR**. 선행 PR 들이 master 로 머지되면 본 PR diff 는 step 4 커밋(`9ed134d`)만 남습니다.

## 변경 내용 (step 4, `9ed134d`)

- `pkg/model/conversion_result.go` — `OpenMxHistogramList` 필드 + getter/setter 추가. 텍스트/OpenMetrics 경로는 native histogram 이 없어 항상 nil → **순수 additive, 기존 스칼라 경로 무영향**.
- `pkg/converter/protobuf_converter.go`
  - **정수 native histogram**: `Schema`/`ZeroThreshold`/`ZeroCount`/`Count`/`Sum` + `Positive`/`Negative` `Span`·`Delta` 를 `OpenMxHistogram` 으로 매핑. bucket delta 인코딩(첫 항=절대값, 이후=delta)을 **그대로 보존**(재인코딩 없음).
  - **float native histogram**(절대 float 카운트 — gauge histogram, float 연산 결과): 정수 스키마(`[]int64` delta / `uint64` count)로 무손실 표현 불가 → **skip + 카운트 로그**. 향후 float 스키마가 필요하면 별도 이슈로 확장.
  - classic 버킷이 함께 노출되면 classic flat series 는 **그대로 수집(무회귀)** — classic 과 native 는 동일 메트릭의 독립 표현이라 둘 다 방출.
  - protobuf 가 소유한 slice 를 alias 하지 않도록 bucket delta 는 방어적 복사.

## 테스트

`pkg/converter/protobuf_converter_test.go`:
- `TestConvertProtobuf_NativeHistogram_IntegerConversion` — ±span/delta 포함 전 필드 매핑, native-only 는 flat series 0건
- `TestConvertProtobuf_DualHistogram_EmitsBoth` — classic flat series + native `OpenMxHistogram` 동시 방출
- `TestConvertProtobuf_FloatNativeHistogram_Skipped` — float native skip, 동시 노출 classic 버킷은 보존

## 검증

- `go build ./pkg/...` ✅
- `go vet ./pkg/converter/... ./pkg/model/...` ✅
- `go test ./pkg/converter/... ./pkg/model/...` ✅ (전 항목 PASS)

> 참고: `pkg/sender/duplicate_check_test.go` 빌드 실패는 본 변경과 무관한 **기존(master) 이슈**(`NewSender` 시그니처 불일치)이며 본 PR 은 `pkg/sender` 를 건드리지 않음.

## 후속

native `OpenMxHistogram` 을 sender/processor 로 **실제 전송 연결**하는 작업은 별도(KAZAA-592 §6-3). 서버 수신 디코더 준비 + 와이어 포맷 최종 사인오프 후 진행.

부모: KAZAA-591 · 스키마: KAZAA-592