### PR TITLE
Fix: mTLS 인증서 주입 동작 수정

### DIFF
--- a/pkg/client/http_client.go
+++ b/pkg/client/http_client.go
@@ -466,44 +466,48 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 			}
 
 			customTLSConfig.RootCAs = rootCAs
+		}
 
-			// Configure client certificate authentication
-			if (tlsConfig.CertFile != "" && tlsConfig.KeyFile != "") || (tlsConfig.CertSecret != nil && tlsConfig.KeySecret != nil) {
-				var certData, keyData []byte
-				var certErr, keyErr error
+		// Configure client certificate authentication (mTLS).
+		// This is independent of InsecureSkipVerify: presenting our client
+		// certificate to the server is unrelated to whether we verify the
+		// server's certificate. Targets such as etcd require a client cert
+		// even when server verification is skipped.
+		if (tlsConfig.CertFile != "" && tlsConfig.KeyFile != "") || (tlsConfig.CertSecret != nil && tlsConfig.KeySecret != nil) {
+			var certData, keyData []byte
+			var certErr, keyErr error
 
-				if tlsConfig.CertFile != "" && tlsConfig.KeyFile != "" {
-					// Load client cert and key from files
-					certData, certErr = loadCertificateFromFile(tlsConfig.CertFile)
-					keyData, keyErr = loadCertificateFromFile(tlsConfig.KeyFile)
-					if configPkg.IsDebugEnabled() {
-						logutil.Debugf("HTTP_CLIENT", "Loading client certificate from files: cert=%s, key=%s", tlsConfig.CertFile, tlsConfig.KeyFile)
-					}
-				} else if tlsConfig.CertSecret != nil && tlsConfig.KeySecret != nil {
-					// Load client cert and key from secrets
-					certData, certErr = loadCertificateFromSecret(tlsConfig.CertSecret)
-					keyData, keyErr = loadCertificateFromSecret(tlsConfig.KeySecret)
-					if configPkg.IsDebugEnabled() {
-						logutil.Debugf("HTTP_CLIENT", "Loading client certificate from secrets: cert=%s/%s, key=%s/%s",
-							tlsConfig.CertSecret.Name, tlsConfig.CertSecret.Key, tlsConfig.KeySecret.Name, tlsConfig.KeySecret.Key)
-					}
+			if tlsConfig.CertFile != "" && tlsConfig.KeyFile != "" {
+				// Load client cert and key from files
+				certData, certErr = loadCertificateFromFile(tlsConfig.CertFile)
+				keyData, keyErr = loadCertificateFromFile(tlsConfig.KeyFile)
+				if configPkg.IsDebugEnabled() {
+					logutil.Debugf("HTTP_CLIENT", "Loading client certificate from files: cert=%s, key=%s", tlsConfig.CertFile, tlsConfig.KeyFile)
 				}
+			} else if tlsConfig.CertSecret != nil && tlsConfig.KeySecret != nil {
+				// Load client cert and key from secrets
+				certData, certErr = loadCertificateFromSecret(tlsConfig.CertSecret)
+				keyData, keyErr = loadCertificateFromSecret(tlsConfig.KeySecret)
+				if configPkg.IsDebugEnabled() {
+					logutil.Debugf("HTTP_CLIENT", "Loading client certificate from secrets: cert=%s/%s, key=%s/%s",
+						tlsConfig.CertSecret.Name, tlsConfig.CertSecret.Key, tlsConfig.KeySecret.Name, tlsConfig.KeySecret.Key)
+				}
+			}
 
-				if certErr == nil && keyErr == nil && len(certData) > 0 && len(keyData) > 0 {
-					if clientCert, err := tls.X509KeyPair(certData, keyData); err == nil {
-						customTLSConfig.Certificates = []tls.Certificate{clientCert}
-						if configPkg.IsDebugEnabled() {
-							logutil.Debugf("HTTP_CLIENT", "Successfully configured client certificate authentication")
-						}
-					} else {
-						if configPkg.IsDebugEnabled() {
-							logutil.Debugf("HTTP_CLIENT", "Failed to create client certificate pair: %v", err)
-						}
+			if certErr == nil && keyErr == nil && len(certData) > 0 && len(keyData) > 0 {
+				if clientCert, err := tls.X509KeyPair(certData, keyData); err == nil {
+					customTLSConfig.Certificates = []tls.Certificate{clientCert}
+					if configPkg.IsDebugEnabled() {
+						logutil.Debugf("HTTP_CLIENT", "Successfully configured client certificate authentication")
 					}
 				} else {
 					if configPkg.IsDebugEnabled() {
-						logutil.Debugf("HTTP_CLIENT", "Failed to load client certificate or key: certErr=%v, keyErr=%v", certErr, keyErr)
+						logutil.Debugf("HTTP_CLIENT", "Failed to create client certificate pair: %v", err)
 					}
+				}
+			} else {
+				if configPkg.IsDebugEnabled() {
+					logutil.Debugf("HTTP_CLIENT", "Failed to load client certificate or key: certErr=%v, keyErr=%v", certErr, keyErr)
 				}
 			}
 		}

--- a/pkg/client/http_client_tls_test.go
+++ b/pkg/client/http_client_tls_test.go
@@ -1,0 +1,196 @@
+package client
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// --- test PKI helpers -------------------------------------------------------
+
+type certPair struct {
+	certPEM []byte
+	keyPEM  []byte
+	cert    tls.Certificate
+	leaf    *x509.Certificate
+}
+
+func mustGenCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Unix(0, 0),
+		NotAfter:              time.Unix(1<<31-1, 0),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("ca cert: %v", err)
+	}
+	caCert, _ := x509.ParseCertificate(der)
+	return caCert, key
+}
+
+func mustGenLeaf(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, server bool) certPair {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Unix(1<<31-1, 0),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	if server {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		tmpl.DNSNames = []string{"localhost"}
+		tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	} else {
+		tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("leaf cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("x509 keypair: %v", err)
+	}
+	leaf, _ := x509.ParseCertificate(der)
+	return certPair{certPEM: certPEM, keyPEM: keyPEM, cert: tlsCert, leaf: leaf}
+}
+
+func writeFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// startMTLSServer starts an HTTPS server that REQUIRES a client certificate
+// signed by caCert (mTLS), mimicking targets like etcd. It serves a fixed body
+// at /metrics.
+func startMTLSServer(t *testing.T, serverCert tls.Certificate, caCert *x509.Certificate) *httptest.Server {
+	t.Helper()
+	clientCAs := x509.NewCertPool()
+	clientCAs.AddCert(caCert)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("etcd_up 1\n"))
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// --- tests ------------------------------------------------------------------
+
+// TestMTLS_InsecureSkipVerifyTrue_PresentsClientCert verifies the core fix:
+// even with insecureSkipVerify=true, the client certificate must still be
+// presented so that mTLS targets (etcd) accept the connection.
+func TestMTLS_InsecureSkipVerifyTrue_PresentsClientCert(t *testing.T) {
+	ca, caKey := mustGenCA(t)
+	server := mustGenLeaf(t, ca, caKey, "localhost", true)
+	clientC := mustGenLeaf(t, ca, caKey, "openagent-client", false)
+
+	srv := startMTLSServer(t, server.cert, ca)
+
+	dir := t.TempDir()
+	caFile := writeFile(t, dir, "ca.crt", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw}))
+	certFile := writeFile(t, dir, "client.crt", clientC.certPEM)
+	keyFile := writeFile(t, dir, "client.key", clientC.keyPEM)
+	_ = caFile
+
+	c := GetInstance()
+	body, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", &TLSConfig{
+		InsecureSkipVerify: true, // skip server verification, but client cert MUST still be sent
+		CertFile:           certFile,
+		KeyFile:            keyFile,
+	}, nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected mTLS request to succeed with insecureSkipVerify=true, got error: %v", err)
+	}
+	if body == "" {
+		t.Fatalf("expected non-empty body")
+	}
+}
+
+// TestMTLS_InsecureSkipVerifyFalse_WithCAFile verifies server verification via
+// caFile together with client cert presentation (full mTLS).
+func TestMTLS_InsecureSkipVerifyFalse_WithCAFile(t *testing.T) {
+	ca, caKey := mustGenCA(t)
+	server := mustGenLeaf(t, ca, caKey, "localhost", true)
+	clientC := mustGenLeaf(t, ca, caKey, "openagent-client", false)
+
+	srv := startMTLSServer(t, server.cert, ca)
+
+	dir := t.TempDir()
+	caFile := writeFile(t, dir, "ca.crt", pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw}))
+	certFile := writeFile(t, dir, "client.crt", clientC.certPEM)
+	keyFile := writeFile(t, dir, "client.key", clientC.keyPEM)
+
+	c := GetInstance()
+	body, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", &TLSConfig{
+		InsecureSkipVerify: false,
+		ServerName:         "localhost",
+		CAFile:             caFile,
+		CertFile:           certFile,
+		KeyFile:            keyFile,
+	}, nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected full-mTLS request to succeed, got error: %v", err)
+	}
+	if body == "" {
+		t.Fatalf("expected non-empty body")
+	}
+}
+
+// TestMTLS_NoClientCert_Fails confirms the test server truly enforces mTLS:
+// without a client cert the request must fail (guards against false positives).
+func TestMTLS_NoClientCert_Fails(t *testing.T) {
+	ca, caKey := mustGenCA(t)
+	server := mustGenLeaf(t, ca, caKey, "localhost", true)
+
+	srv := startMTLSServer(t, server.cert, ca)
+
+	c := GetInstance()
+	_, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", &TLSConfig{
+		InsecureSkipVerify: true, // skip server verify, but provide NO client cert
+	}, nil, 5*time.Second)
+	if err == nil {
+		t.Fatalf("expected request to fail without client certificate, but it succeeded")
+	}
+}

--- a/pkg/scraper/scraper_manager.go
+++ b/pkg/scraper/scraper_manager.go
@@ -17,6 +17,38 @@ import (
 	"open-agent/tools/util/logutil"
 )
 
+// buildTLSConfig converts a tlsConfig map from the scrape configuration into a
+// *client.TLSConfig. It parses all supported fields (not only insecureSkipVerify):
+// the operator renders caSecret/certSecret/keySecret into the caFile/certFile/keyFile
+// paths that are mounted into the agent pod, so those file paths must be read here for
+// server CA validation and mTLS client authentication to work. Returns nil when m is nil.
+func buildTLSConfig(m map[string]interface{}) *client.TLSConfig {
+	if m == nil {
+		return nil
+	}
+	tlsConfig := &client.TLSConfig{}
+	if v, ok := m["insecureSkipVerify"].(bool); ok {
+		tlsConfig.InsecureSkipVerify = v
+	}
+	if v, ok := m["serverName"].(string); ok {
+		tlsConfig.ServerName = v
+	}
+	if v, ok := m["caFile"].(string); ok {
+		tlsConfig.CAFile = v
+	}
+	if v, ok := m["certFile"].(string); ok {
+		tlsConfig.CertFile = v
+	}
+	if v, ok := m["keyFile"].(string); ok {
+		tlsConfig.KeyFile = v
+	}
+	if config.IsDebugEnabled() {
+		logutil.Printf("DEBUG", "[SCRAPER] TLS config: insecureSkipVerify=%v, serverName=%s, caFile=%s, certFile=%s, keyFile=%s",
+			tlsConfig.InsecureSkipVerify, tlsConfig.ServerName, tlsConfig.CAFile, tlsConfig.CertFile, tlsConfig.KeyFile)
+	}
+	return tlsConfig
+}
+
 // TargetScheduler manages individual target scraping with its own goroutine and ticker
 type TargetScheduler struct {
 	target     *discovery.Target
@@ -981,15 +1013,7 @@ func (sm *ScraperManager) createScraperTaskFromTarget(target *discovery.Target) 
 	// Create TLS config if present
 	var tlsConfig *client.TLSConfig
 	if endpoint, ok := target.Metadata["endpoint"].(discovery.EndpointConfig); ok {
-		if endpoint.TLSConfig != nil {
-			tlsConfig = &client.TLSConfig{}
-			if insecureSkipVerify, ok := endpoint.TLSConfig["insecureSkipVerify"].(bool); ok {
-				tlsConfig.InsecureSkipVerify = insecureSkipVerify
-				if config.IsDebugEnabled() {
-					logutil.Printf("DEBUG", "[SCRAPER] TLS config: insecureSkipVerify=%v", insecureSkipVerify)
-				}
-			}
-		}
+		tlsConfig = buildTLSConfig(endpoint.TLSConfig)
 	}
 
 	// Extract node information for proper node label handling
@@ -1268,10 +1292,7 @@ func (sm *ScraperManager) handlePodMonitorTarget(targetName string, targetConfig
 				// Extract TLS configuration
 				var tlsConfig *client.TLSConfig
 				if tlsConfigMap, ok := endpointMap["tlsConfig"].(map[string]interface{}); ok {
-					tlsConfig = &client.TLSConfig{}
-					if insecureSkipVerify, ok := tlsConfigMap["insecureSkipVerify"].(bool); ok {
-						tlsConfig.InsecureSkipVerify = insecureSkipVerify
-					}
+					tlsConfig = buildTLSConfig(tlsConfigMap)
 				}
 
 				// Extract metricRelabelConfigs from metricSelectorConfig
@@ -1369,10 +1390,7 @@ func (sm *ScraperManager) handlePodMonitorTargetWithDummyTarget(targetName strin
 		// Extract TLS configuration
 		var tlsConfig *client.TLSConfig
 		if tlsConfigMap, ok := endpointMap["tlsConfig"].(map[string]interface{}); ok {
-			tlsConfig = &client.TLSConfig{}
-			if insecureSkipVerify, ok := tlsConfigMap["insecureSkipVerify"].(bool); ok {
-				tlsConfig.InsecureSkipVerify = insecureSkipVerify
-			}
+			tlsConfig = buildTLSConfig(tlsConfigMap)
 		}
 
 		// Create a dummy target URL
@@ -1544,10 +1562,7 @@ func (sm *ScraperManager) handleServiceMonitorTarget(targetName string, targetCo
 				// Extract TLS configuration
 				var tlsConfig *client.TLSConfig
 				if tlsConfigMap, ok := endpointMap["tlsConfig"].(map[string]interface{}); ok {
-					tlsConfig = &client.TLSConfig{}
-					if insecureSkipVerify, ok := tlsConfigMap["insecureSkipVerify"].(bool); ok {
-						tlsConfig.InsecureSkipVerify = insecureSkipVerify
-					}
+					tlsConfig = buildTLSConfig(tlsConfigMap)
 				}
 
 				// Extract metricRelabelConfigs from metricSelectorConfig
@@ -1647,10 +1662,7 @@ func (sm *ScraperManager) handleServiceMonitorTargetWithDummyTarget(targetName s
 		// Extract TLS configuration
 		var tlsConfig *client.TLSConfig
 		if tlsConfigMap, ok := endpointMap["tlsConfig"].(map[string]interface{}); ok {
-			tlsConfig = &client.TLSConfig{}
-			if insecureSkipVerify, ok := tlsConfigMap["insecureSkipVerify"].(bool); ok {
-				tlsConfig.InsecureSkipVerify = insecureSkipVerify
-			}
+			tlsConfig = buildTLSConfig(tlsConfigMap)
 		}
 
 		// Extract metricRelabelConfigs
@@ -1721,10 +1733,7 @@ func (sm *ScraperManager) handleStaticEndpointsTarget(targetName string, targetC
 	// Extract TLS configuration
 	var tlsConfig *client.TLSConfig
 	if tlsConfigMap, ok := targetConfig["tlsConfig"].(map[string]interface{}); ok {
-		tlsConfig = &client.TLSConfig{}
-		if insecureSkipVerify, ok := tlsConfigMap["insecureSkipVerify"].(bool); ok {
-			tlsConfig.InsecureSkipVerify = insecureSkipVerify
-		}
+		tlsConfig = buildTLSConfig(tlsConfigMap)
 	}
 
 	// Create a metric selector config

--- a/pkg/scraper/tls_parse_test.go
+++ b/pkg/scraper/tls_parse_test.go
@@ -1,0 +1,42 @@
+package scraper
+
+import "testing"
+
+// TestBuildTLSConfig_ParsesAllFields verifies that buildTLSConfig reads not only
+// insecureSkipVerify but also the caFile/certFile/keyFile/serverName fields that
+// the operator renders into scrape_config (previously these were dropped).
+func TestBuildTLSConfig_ParsesAllFields(t *testing.T) {
+	m := map[string]interface{}{
+		"insecureSkipVerify": true,
+		"serverName":         "localhost",
+		"caFile":             "/etc/ssl/certs/etcd-client-cert/ca.crt",
+		"certFile":           "/etc/ssl/certs/etcd-client-cert/healthcheck-client.crt",
+		"keyFile":            "/etc/ssl/certs/etcd-client-cert/healthcheck-client.key",
+	}
+
+	got := buildTLSConfig(m)
+	if got == nil {
+		t.Fatal("expected non-nil TLSConfig")
+	}
+	if !got.InsecureSkipVerify {
+		t.Errorf("InsecureSkipVerify: want true, got false")
+	}
+	if got.ServerName != "localhost" {
+		t.Errorf("ServerName: want localhost, got %q", got.ServerName)
+	}
+	if got.CAFile != m["caFile"] {
+		t.Errorf("CAFile: want %q, got %q", m["caFile"], got.CAFile)
+	}
+	if got.CertFile != m["certFile"] {
+		t.Errorf("CertFile: want %q, got %q", m["certFile"], got.CertFile)
+	}
+	if got.KeyFile != m["keyFile"] {
+		t.Errorf("KeyFile: want %q, got %q", m["keyFile"], got.KeyFile)
+	}
+}
+
+func TestBuildTLSConfig_NilReturnsNil(t *testing.T) {
+	if got := buildTLSConfig(nil); got != nil {
+		t.Errorf("expected nil for nil map, got %+v", got)
+	}
+}


### PR DESCRIPTION
- scraper_manager: tlsConfig에서 caFile/certFile/keyFile/serverName 파싱 추가 (기존엔 insecureSkipVerify만 읽어 인증서 경로가 무시됨). buildTLSConfig 헬퍼로 6개 파싱 지점 통일.
- http_client: 클라이언트 인증서(mTLS) 로딩을 InsecureSkipVerify 블록 밖으로 분리. 서버 검증 skip 여부와 무관하게 클라이언트 인증서를 제시하도록 하여 etcd 등 mTLS 타깃 수집 가능. 자체 mTLS 서버 기반 단위 테스트 추가.