### PR TITLE
[KUBER-1279] openagent: tlsConfig 인증서 필드 전체 반영 (insecureSkipVerify만 읽던 파싱 수정)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,49 @@ endpoints:
 - 개발 또는 테스트 환경에서 인증서 검증이 필요하지 않을 때
 - 내부 네트워크에서 신뢰할 수 있는 서버에 연결할 때
 
-**주의**: 프로덕션 환경에서는 보안상의 이유로 `insecureSkipVerify: false`를 사용하는 것이 좋습니다. 자체 서명된 인증서를 사용하는 경우, 인증서를 신뢰할 수 있는 인증 기관(CA)으로 추가하는 것이 더 안전한 방법입니다.
+**주의**: 프로덕션 환경에서는 보안상의 이유로 `insecureSkipVerify: false`를 사용하는 것이 좋습니다. 자체 서명된 인증서를 사용하는 경우, 인증서를 신뢰할 수 있는 인증 기관(CA)으로 추가하는 것이 더 안전한 방법입니다(아래 참고).
+
+#### 인증서로 검증 (CA / 클라이언트 인증서)
+
+`insecureSkipVerify: false`(기본값)인 상태에서 다음 필드로 인증서를 적용해 서버를 검증할 수 있습니다. 파일 경로 또는 Kubernetes Secret 참조 중 하나를 사용합니다.
+
+| 필드 | 설명 |
+|------|------|
+| `caFile` | 서버 인증서를 검증할 CA 인증서 파일 경로 |
+| `caSecret` | CA 인증서를 담은 Secret 참조 (`name`/`key`/`namespace`) |
+| `certFile` | mTLS 클라이언트 인증서 파일 경로 |
+| `certSecret` | 클라이언트 인증서 Secret 참조 |
+| `keyFile` | mTLS 클라이언트 개인키 파일 경로 |
+| `keySecret` | 클라이언트 개인키 Secret 참조 |
+| `serverName` | TLS 핸드셰이크에 사용할 SNI 서버 이름 (인증서 CN/SAN과 호스트가 다를 때) |
+
+CA 인증서를 추가해 검증하는 예시:
+
+```yaml
+endpoints:
+  - port: "https"
+    path: "/metrics"
+    scheme: "https"
+    tlsConfig:
+      insecureSkipVerify: false        # 인증서로 정상 검증
+      caSecret:                        # CA 인증서 (또는 caFile 사용)
+        name: "etcd-tls-secret"
+        key: "ca.pem"
+      # mTLS가 필요하면 클라이언트 인증서/키도 함께 지정
+      certSecret:
+        name: "etcd-tls-secret"
+        key: "cert.pem"
+      keySecret:
+        name: "etcd-tls-secret"
+        key: "key.pem"
+      # serverName: "etcd.kube-system.svc"   # 필요 시 SNI 지정
+```
+
+> whatap-operator를 통해 설치하는 경우, `WhatapAgent` CR의 동일한 `tlsConfig` 필드(`caSecret` 등)를 사용하면 오퍼레이터가 Secret을 `/etc/ssl/certs/<secret>/<key>` 경로로 마운트하고 `caFile` 경로로 변환해 전달합니다.
+
+규칙:
+- `caFile`와 `caSecret`는 동시에 지정할 수 없습니다(인증서/키도 동일).
+- 클라이언트 인증서(`certFile`/`certSecret`)를 지정하면 키(`keyFile`/`keySecret`)도 함께 지정해야 하며, 둘은 같은 방식(파일 또는 Secret)으로 맞춰야 합니다.
 
 ### 설정 예제
 

--- a/pkg/scraper/scraper_manager.go
+++ b/pkg/scraper/scraper_manager.go
@@ -978,18 +978,13 @@ func (sm *ScraperManager) createScraperTaskFromTarget(target *discovery.Target) 
 		}
 	}
 
-	// Create TLS config if present
+	// Create TLS config if present.
+	// Parse the full TLS configuration (insecureSkipVerify plus CA/client
+	// certificate and serverName settings) so that certificate-based
+	// verification works, not just insecureSkipVerify. See parseTLSConfig.
 	var tlsConfig *client.TLSConfig
 	if endpoint, ok := target.Metadata["endpoint"].(discovery.EndpointConfig); ok {
-		if endpoint.TLSConfig != nil {
-			tlsConfig = &client.TLSConfig{}
-			if insecureSkipVerify, ok := endpoint.TLSConfig["insecureSkipVerify"].(bool); ok {
-				tlsConfig.InsecureSkipVerify = insecureSkipVerify
-				if config.IsDebugEnabled() {
-					logutil.Printf("DEBUG", "[SCRAPER] TLS config: insecureSkipVerify=%v", insecureSkipVerify)
-				}
-			}
-		}
+		tlsConfig = parseTLSConfig(endpoint.TLSConfig)
 	}
 
 	// Extract node information for proper node label handling
@@ -1766,3 +1761,80 @@ func (sm *ScraperManager) handleStaticEndpointsTarget(targetName string, targetC
 	}
 }
 */
+
+// parseTLSConfig converts a raw tlsConfig map (as parsed from the scrape config
+// YAML) into a *client.TLSConfig, preserving every TLS field. Previously only
+// insecureSkipVerify was read, which silently dropped any certificate the user
+// applied (caFile/caSecret, certFile/certSecret, keyFile/keySecret, serverName);
+// an https target with a CA certificate then failed the TLS handshake
+// ("x509: certificate signed by unknown authority"), forcing users to fall back
+// to insecureSkipVerify: true. The http client (client.ExecuteGetWithAuthResponse)
+// already loads all of these fields, so honoring them here lets certificate-based
+// verification work end to end.
+//
+// A nil map yields a nil config (no custom transport); a present-but-empty map
+// yields an empty config, matching the previous behavior.
+func parseTLSConfig(tlsConfigMap map[string]interface{}) *client.TLSConfig {
+	if tlsConfigMap == nil {
+		return nil
+	}
+
+	tlsConfig := &client.TLSConfig{}
+
+	if insecureSkipVerify, ok := tlsConfigMap["insecureSkipVerify"].(bool); ok {
+		tlsConfig.InsecureSkipVerify = insecureSkipVerify
+	}
+	if caFile, ok := tlsConfigMap["caFile"].(string); ok {
+		tlsConfig.CAFile = caFile
+	}
+	if certFile, ok := tlsConfigMap["certFile"].(string); ok {
+		tlsConfig.CertFile = certFile
+	}
+	if keyFile, ok := tlsConfigMap["keyFile"].(string); ok {
+		tlsConfig.KeyFile = keyFile
+	}
+	if serverName, ok := tlsConfigMap["serverName"].(string); ok {
+		tlsConfig.ServerName = serverName
+	}
+	if caSecret := parseSecretKeySelector(tlsConfigMap["caSecret"]); caSecret != nil {
+		tlsConfig.CASecret = caSecret
+	}
+	if certSecret := parseSecretKeySelector(tlsConfigMap["certSecret"]); certSecret != nil {
+		tlsConfig.CertSecret = certSecret
+	}
+	if keySecret := parseSecretKeySelector(tlsConfigMap["keySecret"]); keySecret != nil {
+		tlsConfig.KeySecret = keySecret
+	}
+
+	if config.IsDebugEnabled() {
+		logutil.Printf("DEBUG", "[SCRAPER] TLS config: insecureSkipVerify=%v caFile=%q certFile=%q keyFile=%q serverName=%q caSecret=%v certSecret=%v keySecret=%v",
+			tlsConfig.InsecureSkipVerify, tlsConfig.CAFile, tlsConfig.CertFile, tlsConfig.KeyFile, tlsConfig.ServerName,
+			tlsConfig.CASecret != nil, tlsConfig.CertSecret != nil, tlsConfig.KeySecret != nil)
+	}
+
+	return tlsConfig
+}
+
+// parseSecretKeySelector converts a raw map (name/key/namespace) from the scrape
+// config YAML into a *config.SecretKeySelector. It returns nil when the value is
+// absent or not a map. The config loader normalizes nested maps to string keys
+// (see config_manager.convertToStringMap), so a map[string]interface{} assertion
+// is safe here.
+func parseSecretKeySelector(raw interface{}) *config.SecretKeySelector {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	selector := &config.SecretKeySelector{}
+	if name, ok := m["name"].(string); ok {
+		selector.Name = name
+	}
+	if key, ok := m["key"].(string); ok {
+		selector.Key = key
+	}
+	if namespace, ok := m["namespace"].(string); ok {
+		selector.Namespace = namespace
+	}
+	return selector
+}

--- a/pkg/scraper/tls_config_test.go
+++ b/pkg/scraper/tls_config_test.go
@@ -1,0 +1,95 @@
+package scraper
+
+import "testing"
+
+// TestParseTLSConfig_FullCertFields verifies that every TLS field is parsed from
+// the raw tlsConfig map. This is a regression test for the bug where only
+// insecureSkipVerify was honored and any applied certificate (caFile/caSecret,
+// certFile/certSecret, keyFile/keySecret, serverName) was silently dropped.
+func TestParseTLSConfig_FullCertFields(t *testing.T) {
+	raw := map[string]interface{}{
+		"insecureSkipVerify": false,
+		"caFile":             "/etc/ssl/certs/etcd-tls/ca.pem",
+		"certFile":           "/etc/ssl/certs/etcd-tls/cert.pem",
+		"keyFile":            "/etc/ssl/certs/etcd-tls/key.pem",
+		"serverName":         "etcd.kube-system.svc",
+	}
+
+	tc := parseTLSConfig(raw)
+	if tc == nil {
+		t.Fatal("parseTLSConfig returned nil for a non-nil map")
+	}
+	if tc.InsecureSkipVerify != false {
+		t.Errorf("InsecureSkipVerify = %v, want false", tc.InsecureSkipVerify)
+	}
+	if tc.CAFile != "/etc/ssl/certs/etcd-tls/ca.pem" {
+		t.Errorf("CAFile = %q, want the CA path", tc.CAFile)
+	}
+	if tc.CertFile != "/etc/ssl/certs/etcd-tls/cert.pem" {
+		t.Errorf("CertFile = %q, want the cert path", tc.CertFile)
+	}
+	if tc.KeyFile != "/etc/ssl/certs/etcd-tls/key.pem" {
+		t.Errorf("KeyFile = %q, want the key path", tc.KeyFile)
+	}
+	if tc.ServerName != "etcd.kube-system.svc" {
+		t.Errorf("ServerName = %q, want etcd.kube-system.svc", tc.ServerName)
+	}
+}
+
+// TestParseTLSConfig_SecretSelectors verifies that caSecret/certSecret/keySecret
+// nested maps are parsed into SecretKeySelectors.
+func TestParseTLSConfig_SecretSelectors(t *testing.T) {
+	raw := map[string]interface{}{
+		"caSecret":   map[string]interface{}{"name": "etcd-tls", "key": "ca.pem"},
+		"certSecret": map[string]interface{}{"name": "etcd-tls", "key": "cert.pem", "namespace": "kube-system"},
+		"keySecret":  map[string]interface{}{"name": "etcd-tls", "key": "key.pem"},
+	}
+
+	tc := parseTLSConfig(raw)
+	if tc == nil {
+		t.Fatal("parseTLSConfig returned nil for a non-nil map")
+	}
+	if tc.CASecret == nil || tc.CASecret.Name != "etcd-tls" || tc.CASecret.Key != "ca.pem" {
+		t.Errorf("CASecret = %+v, want {etcd-tls ca.pem}", tc.CASecret)
+	}
+	if tc.CertSecret == nil || tc.CertSecret.Key != "cert.pem" || tc.CertSecret.Namespace != "kube-system" {
+		t.Errorf("CertSecret = %+v, want cert.pem in kube-system", tc.CertSecret)
+	}
+	if tc.KeySecret == nil || tc.KeySecret.Key != "key.pem" {
+		t.Errorf("KeySecret = %+v, want key.pem", tc.KeySecret)
+	}
+}
+
+// TestParseTLSConfig_InsecureSkipVerify verifies the insecureSkipVerify path
+// still works (the previously-only-supported field).
+func TestParseTLSConfig_InsecureSkipVerify(t *testing.T) {
+	tc := parseTLSConfig(map[string]interface{}{"insecureSkipVerify": true})
+	if tc == nil || !tc.InsecureSkipVerify {
+		t.Fatalf("InsecureSkipVerify not honored: %+v", tc)
+	}
+}
+
+// TestParseTLSConfig_NilAndEmpty verifies behavior preservation: a nil map yields
+// a nil config (default transport), a present-but-empty map yields an empty config.
+func TestParseTLSConfig_NilAndEmpty(t *testing.T) {
+	if tc := parseTLSConfig(nil); tc != nil {
+		t.Errorf("parseTLSConfig(nil) = %+v, want nil", tc)
+	}
+	tc := parseTLSConfig(map[string]interface{}{})
+	if tc == nil {
+		t.Fatal("parseTLSConfig(empty map) = nil, want non-nil empty config")
+	}
+	if tc.InsecureSkipVerify || tc.CAFile != "" || tc.CASecret != nil {
+		t.Errorf("empty map produced non-empty config: %+v", tc)
+	}
+}
+
+// TestParseSecretKeySelector_NotAMap verifies non-map values return nil.
+func TestParseSecretKeySelector_NotAMap(t *testing.T) {
+	if got := parseSecretKeySelector("not-a-map"); got != nil {
+		t.Errorf("parseSecretKeySelector(string) = %+v, want nil", got)
+	}
+	if got := parseSecretKeySelector(nil); got != nil {
+		t.Errorf("parseSecretKeySelector(nil) = %+v, want nil", got)
+	}
+}


### PR DESCRIPTION
## 배경 (KUBER-1279 / 카카오뱅크)

https 스크랩 타겟에 CA 인증서를 적용(`caFile`/`caSecret` + `insecureSkipVerify: false`)해도 openagent가 인증서를 무시해 `x509: certificate signed by unknown authority`로 실패하고, 유일한 우회책이 `insecureSkipVerify: true`였습니다.

## 원인

`pkg/scraper/scraper_manager.go`의 `createScraperTaskFromTarget`이 타겟 `tlsConfig`에서 **`insecureSkipVerify`만 읽고** 나머지 인증서 필드(`caFile`/`caSecret`, `certFile`/`certSecret`, `keyFile`/`keySecret`, `serverName`)를 전부 버리고 있었습니다.

- HTTP 클라이언트(`http_client.go ExecuteGetWithAuthResponse`)는 CA/클라이언트 인증서/SNI를 이미 전부 로드함
- whatap-operator도 `tlsConfig`를 Secret 마운트 + `caFile` 경로로 정상 렌더링함
- → 끊긴 고리는 이 파싱 한 곳뿐 (동일 패턴 5곳은 주석 처리된 죽은 코드)

## 변경

- `parseTLSConfig` / `parseSecretKeySelector` 헬퍼 추가 — `tlsConfig` 맵의 전체 필드를 `client.TLSConfig`로 전달
- 회귀 방지: nil 맵 → nil 반환(커스텀 transport 없음), 빈 맵 → 빈 config — 기존 동작 보존
- 유닛 테스트 5개 추가 (`scraper_manager_tls_test.go`)
- README에 인증서 기반 TLS 설정 문서 추가

## 검증

- `go build ./pkg/...` PASS
- `go test ./pkg/scraper/...` PASS (신규 테스트 5개 포함)
- `go vet` / `gofmt` PASS

관련 이슈: KUBER-1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)