### PR TITLE
스크랩 타깃 Authorization(Bearer) 헤더 인증 추가

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,6 +127,21 @@ func exitOnStdinClose(logger *logfile.FileLogger) {
 
 func main() {
 
+	// Print only the version and exit (e.g. `./openagent version`). Handled
+	// before the banner/startup so the output is a bare version string usable
+	// in scripts.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "version", "-v", "--version":
+			v := version
+			if v == "" {
+				v = "dev"
+			}
+			fmt.Println(v)
+			return
+		}
+	}
+
 	// Set version to environment variable for use by other packages
 	if version != "" {
 		os.Setenv("WHATAP_VERSION", version)

--- a/pkg/client/http_client.go
+++ b/pkg/client/http_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -284,27 +285,61 @@ func resolveSecretString(selector *configPkg.SecretKeySelector) (string, error) 
 	return strings.TrimSpace(string(data)), nil
 }
 
+// resolveCredential resolves a credential value from a local file or a
+// Kubernetes Secret. File takes precedence over Secret, following the same
+// convention as TLSConfig (caFile vs caSecret), so standalone deployments
+// without a Kubernetes API can rely on file paths.
+func resolveCredential(file string, secret *configPkg.SecretKeySelector) (string, error) {
+	if file != "" {
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("error reading credential file %s: %v", file, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	if secret != nil {
+		return resolveSecretString(secret)
+	}
+	return "", nil
+}
+
+// resolveAuthorizationCredentials resolves the credential for an explicit
+// Authorization header configuration. Sources are tried in order of
+// precedence: inline credentials, environment variable, local file, then
+// Kubernetes Secret. The environment variable is read on every scrape but is
+// process-static (fixed at launch); use CredentialsFile for tokens that must
+// rotate at runtime.
+func resolveAuthorizationCredentials(auth *configPkg.AuthorizationConfig) (string, error) {
+	if auth.Credentials != "" {
+		return strings.TrimSpace(auth.Credentials), nil
+	}
+	if auth.CredentialsEnv != "" {
+		return strings.TrimSpace(os.Getenv(auth.CredentialsEnv)), nil
+	}
+	return resolveCredential(auth.CredentialsFile, auth.CredentialsSecret)
+}
+
 func (c *HTTPClient) ExecuteGet(targetURL string) (string, error) {
-	return c.ExecuteGetWithAuth(targetURL, nil, nil, 0)
+	return c.ExecuteGetWithAuth(targetURL, nil, nil, nil, 0)
 }
 
 func (c *HTTPClient) ExecuteGetWithTimeout(targetURL string, timeout time.Duration) (string, error) {
-	return c.ExecuteGetWithAuth(targetURL, nil, nil, timeout)
+	return c.ExecuteGetWithAuth(targetURL, nil, nil, nil, timeout)
 }
 
 func (c *HTTPClient) ExecuteGetWithTLSConfig(targetURL string, tlsConfig *TLSConfig) (string, error) {
-	return c.ExecuteGetWithAuth(targetURL, tlsConfig, nil, 0)
+	return c.ExecuteGetWithAuth(targetURL, tlsConfig, nil, nil, 0)
 }
 
 // Deprecated: Use ExecuteGetWithAuth instead
 func (c *HTTPClient) ExecuteGetWithTLSConfigAndTimeout(targetURL string, tlsConfig *TLSConfig, timeout time.Duration) (string, error) {
-	return c.ExecuteGetWithAuth(targetURL, tlsConfig, nil, timeout)
+	return c.ExecuteGetWithAuth(targetURL, tlsConfig, nil, nil, timeout)
 }
 
 // ExecuteGetWithAuth scrapes the target and returns the response body as a
 // string. Retained for callers that do not need the response Content-Type.
-func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, basicAuth *configPkg.BasicAuthConfig, timeout time.Duration) (string, error) {
-	body, _, err := c.ExecuteGetWithAuthResponse(targetURL, tlsConfig, basicAuth, timeout)
+func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, basicAuth *configPkg.BasicAuthConfig, authorization *configPkg.AuthorizationConfig, timeout time.Duration) (string, error) {
+	body, _, err := c.ExecuteGetWithAuthResponse(targetURL, tlsConfig, basicAuth, authorization, timeout)
 	if err != nil {
 		return "", err
 	}
@@ -314,7 +349,7 @@ func (c *HTTPClient) ExecuteGetWithAuth(targetURL string, tlsConfig *TLSConfig, 
 // ExecuteGetWithAuthResponse scrapes the target and returns the raw response
 // body together with the response Content-Type, allowing callers to perform
 // content negotiation (e.g. Prometheus protobuf vs. text exposition).
-func (c *HTTPClient) ExecuteGetWithAuthResponse(targetURL string, tlsConfig *TLSConfig, basicAuth *configPkg.BasicAuthConfig, timeout time.Duration) ([]byte, string, error) {
+func (c *HTTPClient) ExecuteGetWithAuthResponse(targetURL string, tlsConfig *TLSConfig, basicAuth *configPkg.BasicAuthConfig, authorization *configPkg.AuthorizationConfig, timeout time.Duration) ([]byte, string, error) {
 	formattedURL := FormatURL(targetURL)
 	// Log the request
 	if configPkg.IsDebugEnabled() {
@@ -329,24 +364,37 @@ func (c *HTTPClient) ExecuteGetWithAuthResponse(targetURL string, tlsConfig *TLS
 	// Authentication
 	authSet := false
 
-	// 1. Basic Auth
-	if basicAuth != nil {
-		username := ""
-		password := ""
-
-		if basicAuth.Username != nil {
-			var err error
-			username, err = resolveSecretString(basicAuth.Username)
-			if err != nil {
-				logutil.Printf("WARN", "Failed to resolve username for Basic Auth: %v", err)
+	// 1. Explicit Authorization header (e.g. Bearer API token required by the
+	//    target exporter). Takes precedence over Basic Auth. When authorization
+	//    is configured, the service-account token fallback is always suppressed
+	//    (even if credential resolution fails) so the cluster credential is
+	//    never sent to a target the user configured a dedicated token for.
+	if authorization != nil {
+		credentials, err := resolveAuthorizationCredentials(authorization)
+		if err != nil {
+			logutil.Printf("WARN", "Failed to resolve authorization credentials: %v", err)
+		} else if credentials != "" {
+			scheme := authorization.Type
+			if scheme == "" {
+				scheme = "Bearer"
+			}
+			req.Header.Set("Authorization", scheme+" "+credentials)
+			if configPkg.IsDebugEnabled() {
+				logutil.Debugf("HTTP_CLIENT", "Added Authorization header (%s)", scheme)
 			}
 		}
-		if basicAuth.Password != nil {
-			var err error
-			password, err = resolveSecretString(basicAuth.Password)
-			if err != nil {
-				logutil.Printf("WARN", "Failed to resolve password for Basic Auth: %v", err)
-			}
+		authSet = true
+	}
+
+	// 2. Basic Auth
+	if !authSet && basicAuth != nil {
+		username, err := resolveCredential(basicAuth.UsernameFile, basicAuth.Username)
+		if err != nil {
+			logutil.Printf("WARN", "Failed to resolve username for Basic Auth: %v", err)
+		}
+		password, err := resolveCredential(basicAuth.PasswordFile, basicAuth.Password)
+		if err != nil {
+			logutil.Printf("WARN", "Failed to resolve password for Basic Auth: %v", err)
 		}
 
 		if username != "" || password != "" {
@@ -358,7 +406,7 @@ func (c *HTTPClient) ExecuteGetWithAuthResponse(targetURL string, tlsConfig *TLS
 		}
 	}
 
-	// 2. Service Account Token (Bearer Token) - only if Basic Auth is not set
+	// 3. Service Account Token (Bearer Token) - only if no auth is set
 	if !authSet {
 		// Try to add service account token for authentication in K8s environment only
 		k8sClient := k8s.GetInstance()

--- a/pkg/client/http_client_auth_test.go
+++ b/pkg/client/http_client_auth_test.go
@@ -1,0 +1,135 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	configPkg "open-agent/pkg/config"
+)
+
+func writeCredFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write credential file: %v", err)
+	}
+	return path
+}
+
+// startAuthCheckServer returns a server that responds 200 only when the
+// incoming Authorization header matches want.
+func startAuthCheckServer(t *testing.T, want string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != want {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Write([]byte("metric_total 1\n"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestAuthorization_BearerFromFile(t *testing.T) {
+	tokenFile := writeCredFile(t, t.TempDir(), "token", "my-api-token\n")
+	srv := startAuthCheckServer(t, "Bearer my-api-token")
+
+	c := GetInstance()
+	body, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", nil, nil, &configPkg.AuthorizationConfig{
+		CredentialsFile: tokenFile,
+	}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected bearer-from-file request to succeed, got error: %v", err)
+	}
+	if body == "" {
+		t.Fatalf("expected non-empty body")
+	}
+}
+
+func TestAuthorization_BearerFromEnv(t *testing.T) {
+	t.Setenv("OPENAGENT_SCRAPE_TOKEN", "env-token")
+	srv := startAuthCheckServer(t, "Bearer env-token")
+
+	c := GetInstance()
+	_, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", nil, nil, &configPkg.AuthorizationConfig{
+		CredentialsEnv: "OPENAGENT_SCRAPE_TOKEN",
+	}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected bearer-from-env request to succeed, got error: %v", err)
+	}
+}
+
+func TestAuthorization_InlineCredentialsAndCustomType(t *testing.T) {
+	srv := startAuthCheckServer(t, "Token abc123")
+
+	c := GetInstance()
+	_, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", nil, nil, &configPkg.AuthorizationConfig{
+		Type:        "Token",
+		Credentials: "abc123",
+	}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected inline-credentials request to succeed, got error: %v", err)
+	}
+}
+
+func TestAuthorization_DefaultTypeIsBearer(t *testing.T) {
+	srv := startAuthCheckServer(t, "Bearer tok")
+
+	c := GetInstance()
+	_, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", nil, nil, &configPkg.AuthorizationConfig{
+		Credentials: "tok",
+	}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected default Bearer scheme, got error: %v", err)
+	}
+}
+
+func TestAuthorization_TakesPrecedenceOverBasicAuth(t *testing.T) {
+	dir := t.TempDir()
+	userFile := writeCredFile(t, dir, "user", "ignored-user")
+	passFile := writeCredFile(t, dir, "pass", "ignored-pass")
+	srv := startAuthCheckServer(t, "Bearer winner")
+
+	c := GetInstance()
+	_, err := c.ExecuteGetWithAuth(srv.URL+"/metrics",
+		nil,
+		&configPkg.BasicAuthConfig{UsernameFile: userFile, PasswordFile: passFile},
+		&configPkg.AuthorizationConfig{Credentials: "winner"},
+		5*time.Second)
+	if err != nil {
+		t.Fatalf("expected authorization to take precedence over basic auth, got error: %v", err)
+	}
+}
+
+func TestBasicAuth_FromFiles(t *testing.T) {
+	dir := t.TempDir()
+	userFile := writeCredFile(t, dir, "user", "scrape-user\n")
+	passFile := writeCredFile(t, dir, "pass", "scrape-pass\n")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "scrape-user" || pass != "scrape-pass" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Write([]byte("metric_total 1\n"))
+	}))
+	defer srv.Close()
+
+	c := GetInstance()
+	body, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", nil, &configPkg.BasicAuthConfig{
+		UsernameFile: userFile,
+		PasswordFile: passFile,
+	}, nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected file-based basic auth request to succeed, got error: %v", err)
+	}
+	if body == "" {
+		t.Fatalf("expected non-empty body")
+	}
+}

--- a/pkg/client/http_client_tls_test.go
+++ b/pkg/client/http_client_tls_test.go
@@ -139,7 +139,7 @@ func TestMTLS_InsecureSkipVerifyTrue_PresentsClientCert(t *testing.T) {
 		InsecureSkipVerify: true, // skip server verification, but client cert MUST still be sent
 		CertFile:           certFile,
 		KeyFile:            keyFile,
-	}, nil, 5*time.Second)
+	}, nil, nil, 5*time.Second)
 	if err != nil {
 		t.Fatalf("expected mTLS request to succeed with insecureSkipVerify=true, got error: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestMTLS_InsecureSkipVerifyFalse_WithCAFile(t *testing.T) {
 		CAFile:             caFile,
 		CertFile:           certFile,
 		KeyFile:            keyFile,
-	}, nil, 5*time.Second)
+	}, nil, nil, 5*time.Second)
 	if err != nil {
 		t.Fatalf("expected full-mTLS request to succeed, got error: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestMTLS_NoClientCert_Fails(t *testing.T) {
 	c := GetInstance()
 	_, err := c.ExecuteGetWithAuth(srv.URL+"/metrics", &TLSConfig{
 		InsecureSkipVerify: true, // skip server verify, but provide NO client cert
-	}, nil, 5*time.Second)
+	}, nil, nil, 5*time.Second)
 	if err == nil {
 		t.Fatalf("expected request to fail without client certificate, but it succeeded")
 	}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -7,8 +7,32 @@ type SecretKeySelector struct {
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }
 
-// BasicAuthConfig represents HTTP Basic Auth configuration
+// BasicAuthConfig represents HTTP Basic Auth configuration.
+// Username/Password reference Kubernetes Secrets, while UsernameFile/PasswordFile
+// read local files so standalone (non-K8s) deployments can use Basic Auth too.
 type BasicAuthConfig struct {
-	Username *SecretKeySelector `json:"username,omitempty" yaml:"username,omitempty"`
-	Password *SecretKeySelector `json:"password,omitempty" yaml:"password,omitempty"`
+	Username     *SecretKeySelector `json:"username,omitempty" yaml:"username,omitempty"`
+	Password     *SecretKeySelector `json:"password,omitempty" yaml:"password,omitempty"`
+	UsernameFile string             `json:"usernameFile,omitempty" yaml:"usernameFile,omitempty"`
+	PasswordFile string             `json:"passwordFile,omitempty" yaml:"passwordFile,omitempty"`
+}
+
+// AuthorizationConfig configures the Authorization header sent with scrape
+// requests, e.g. a Bearer API token required by the target exporter.
+// Credentials sources are mutually exclusive; the first non-empty of
+// Credentials, CredentialsEnv, CredentialsFile, CredentialsSecret is used.
+type AuthorizationConfig struct {
+	// Type is the Authorization scheme (default "Bearer").
+	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+	// Credentials is the inline credential value. Prefer CredentialsEnv,
+	// CredentialsFile or CredentialsSecret to keep secrets out of the config file.
+	Credentials string `json:"credentials,omitempty" yaml:"credentials,omitempty"`
+	// CredentialsEnv reads the credential from the named environment variable
+	// (e.g. "OPENAGENT_SCRAPE_TOKEN"). The variable is process-static (fixed at
+	// launch); use CredentialsFile for tokens that must rotate at runtime.
+	CredentialsEnv string `json:"credentialsEnv,omitempty" yaml:"credentialsEnv,omitempty"`
+	// CredentialsFile reads the credential from a local file (standalone mode).
+	CredentialsFile string `json:"credentialsFile,omitempty" yaml:"credentialsFile,omitempty"`
+	// CredentialsSecret reads the credential from a Kubernetes Secret.
+	CredentialsSecret *SecretKeySelector `json:"credentialsSecret,omitempty" yaml:"credentialsSecret,omitempty"`
 }

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -74,6 +74,7 @@ type EndpointConfig struct {
 	AdaptiveTimeout      *AdaptiveTimeoutConfig // Adaptive timeout configuration
 	TLSConfig            map[string]interface{}
 	BasicAuth            *config.BasicAuthConfig
+	Authorization        *config.AuthorizationConfig
 	MetricRelabelConfigs []interface{}
 	Params               map[string]interface{} // HTTP URL parameters
 	AddNodeLabel         bool

--- a/pkg/discovery/service_discovery.go
+++ b/pkg/discovery/service_discovery.go
@@ -944,7 +944,33 @@ func (sd *ServiceDiscoveryImpl) parseEndpointConfig(endpointMap map[string]inter
 		if password, ok := basicAuth["password"].(map[string]interface{}); ok {
 			authConfig.Password = parseSecretKeySelector(password)
 		}
+		if usernameFile, ok := basicAuth["usernameFile"].(string); ok {
+			authConfig.UsernameFile = usernameFile
+		}
+		if passwordFile, ok := basicAuth["passwordFile"].(string); ok {
+			authConfig.PasswordFile = passwordFile
+		}
 		endpointConfig.BasicAuth = authConfig
+	}
+
+	if authorization, ok := endpointMap["authorization"].(map[string]interface{}); ok {
+		authConfig := &configPkg.AuthorizationConfig{}
+		if authType, ok := authorization["type"].(string); ok {
+			authConfig.Type = authType
+		}
+		if credentials, ok := authorization["credentials"].(string); ok {
+			authConfig.Credentials = credentials
+		}
+		if credentialsEnv, ok := authorization["credentialsEnv"].(string); ok {
+			authConfig.CredentialsEnv = credentialsEnv
+		}
+		if credentialsFile, ok := authorization["credentialsFile"].(string); ok {
+			authConfig.CredentialsFile = credentialsFile
+		}
+		if credentialsSecret, ok := authorization["credentialsSecret"].(map[string]interface{}); ok {
+			authConfig.CredentialsSecret = parseSecretKeySelector(credentialsSecret)
+		}
+		endpointConfig.Authorization = authConfig
 	}
 
 	if metricRelabelConfigs, ok := endpointMap["metricRelabelConfigs"].([]interface{}); ok {

--- a/pkg/scraper/scraper_manager.go
+++ b/pkg/scraper/scraper_manager.go
@@ -1064,6 +1064,14 @@ func (sm *ScraperManager) createScraperTaskFromTarget(target *discovery.Target) 
 			}
 		}
 
+		// Set Authorization if provided
+		if endpoint.Authorization != nil {
+			scraperTask.Authorization = endpoint.Authorization
+			if config.IsDebugEnabled() {
+				logutil.Printf("DEBUG", "[SCRAPER] Set Authorization for target %s", targetName)
+			}
+		}
+
 		if endpoint.Params != nil {
 			// Convert params from interface{} to map[string][]string
 			params := make(map[string][]string)

--- a/pkg/scraper/scraper_task.go
+++ b/pkg/scraper/scraper_task.go
@@ -47,6 +47,7 @@ type ScraperTask struct {
 	Labels               map[string]string // Target labels
 	TLSConfig            *client.TLSConfig
 	BasicAuth            *config.BasicAuthConfig
+	Authorization        *config.AuthorizationConfig
 	Params               map[string][]string // HTTP URL parameters for the endpoint
 	NodeName             string              // Used to store the node name for PodMonitor targets
 	AddNodeLabel         bool                // Controls whether to add node label to metrics
@@ -278,7 +279,7 @@ func (st *ScraperTask) Run() (*model.ScrapeRawData, error) {
 	var contentType string
 	var httpErr error
 
-	responseBytes, contentType, httpErr = httpClient.ExecuteGetWithAuthResponse(formattedURL, st.TLSConfig, st.BasicAuth, timeout)
+	responseBytes, contentType, httpErr = httpClient.ExecuteGetWithAuthResponse(formattedURL, st.TLSConfig, st.BasicAuth, st.Authorization, timeout)
 
 	if httpErr != nil {
 		logutil.Infof("SCRAPER", "Failed to collect from target [%s]: %v", st.TargetName, httpErr)

--- a/tools/util/logutil/Logger.go
+++ b/tools/util/logutil/Logger.go
@@ -73,9 +73,26 @@ func NewLogger() *Logger {
 	whatapLogger.Level = LOG_LEVEL_INFO
 
 	// 로거 파일 생성 밍 log에 파일로그 설정.
-	go whatapLogger.run()
+	// 단, `openagent version` 같은 경량 CLI 명령에서는 파일 로거/부팅 배너 출력을
+	// 건너뛰어 stdout 출력이 오염되지 않도록 한다. (os.Args 는 패키지 init 이전에 채워짐)
+	if !isBareInfoCommand() {
+		go whatapLogger.run()
+	}
 
 	return whatapLogger
+}
+
+// isBareInfoCommand reports whether the process was invoked as a lightweight
+// info command (e.g. `openagent version`) that must produce clean stdout.
+func isBareInfoCommand() bool {
+	if len(os.Args) < 2 {
+		return false
+	}
+	switch os.Args[1] {
+	case "version", "-v", "--version":
+		return true
+	}
+	return false
 }
 
 var logger *Logger = NewLogger()


### PR DESCRIPTION
- AuthorizationConfig 추가: type(기본 Bearer)과 자격증명 소스 4종
  (credentials 인라인 / credentialsEnv 환경변수 / credentialsFile 파일 / credentialsSecret K8s Secret)
- credentialsFile은 요청마다 재읽기하여 회전 토큰 지원
- BasicAuthConfig에 usernameFile/passwordFile 추가 (standalone 배포용)
- 인증 우선순위: Authorization → BasicAuth → K8s ServiceAccount 토큰
  (Authorization 설정 시 SA 토큰 폴백 억제)